### PR TITLE
Return `Ok` variant for responses with 2xx status codes.

### DIFF
--- a/src/browser/task.ml
+++ b/src/browser/task.ml
@@ -186,7 +186,7 @@ let http_text
     let handler _ =
         assert (Http_request.ready_state req = 4);
         let status = Http_request.status req in
-        if status <> 200 then (* not ok *)
+        if status >= 300 then (* not ok *)
             continue k (Error (`Http_status status))
         else
             continue k (Ok (Http_request.response_text_string req))

--- a/src/browser/task.ml
+++ b/src/browser/task.ml
@@ -210,7 +210,7 @@ let http_json
     let handler _ =
         assert (Http_request.ready_state req = 4);
         let status = Http_request.status req in
-        if status <> 200 then (* not ok *)
+        if status >= 300 then (* not ok *)
             continue k (Error (`Http_status status))
         else
             match


### PR DESCRIPTION
I was using fmlib_browser recently and was surprised to get an Error variant for a 201 response. 
I think any 2xx status code should represent a successful request. 