### PR TITLE
introduce module HTTP and generic request function

### DIFF
--- a/src/browser/task.ml
+++ b/src/browser/task.ml
@@ -3,8 +3,6 @@ open Fmlib_js
 
 type empty = |
 
-type http_error = [`Http_status of int | `Http_no_json | `Http_decode]
-
 type not_found  = [`Not_found]
 
 let absurd: empty -> 'a = function
@@ -174,61 +172,108 @@ let random (rand: 'a Random.t): ('a, 'e) t =
 
 
 
-let http_text
-        (meth: string)
-        (url: string)
-        (headers: (string * string) list)
-        (body: string)
-    : (string, http_error) t
-    =
-    fun _ k ->
-    let req = Http_request.make meth url headers body in
-    let handler _ =
-        assert (Http_request.ready_state req = 4);
-        let status = Http_request.status req in
-        if status >= 300 then (* not ok *)
-            continue k (Error (`Http_status status))
-        else
-            continue k (Ok (Http_request.response_text_string req))
-    in
-    Event_target.add
-        "loadend"
-        handler
-        (Http_request.event_target req)
+module Http =
+struct
+    module Error =
+    struct
+        type t = [ `Status of int | `No_json | `Decode ]
+    end
 
 
-let http_json
-        (meth: string)
-        (url: string)
-        (headers: (string * string) list)
-        (body: string)
-        (decode: 'a Base.Decode.t)
-    : ('a, http_error) t
-    =
-    fun _ k ->
-    let req = Http_request.make meth url headers body in
-    let handler _ =
-        assert (Http_request.ready_state req = 4);
-        let status = Http_request.status req in
-        if status >= 300 then (* not ok *)
-            continue k (Error (`Http_status status))
-        else
-            match
-                Base.Value.parse (Http_request.response_text_value req)
-            with
+    module Body =
+    struct
+        type t = string
+
+        let empty : t = ""
+
+        let string (s : string) : t = s
+
+        let json (v : Base.Value.t) : t =
+            (* it's ok to call Option.get here because v is constructed with one of
+               the functions from Fmlib_browser.Value and thus is guaranteed to be
+               serializable *)
+            v
+            |> Base.Value.stringify
+            |> Option.get
+            |> Base.Decode.string
+            |> Option.get
+    end
+
+
+    module Expect =
+    struct
+        type 'a t = Http_request.t -> ('a, Error.t) result
+
+        let string : string t =
+            fun req ->
+            Ok (Http_request.response_text_string req)
+
+        let json (decode : 'a Base.Decode.t) : 'a t =
+            fun req ->
+            match Base.Value.parse (Http_request.response_text_value req) with
             | None ->
-                continue k (Error `Http_no_json)
+                Error `No_json
             | Some v ->
                 match decode v with
                 | None ->
-                    continue k (Error `Http_decode)
+                    Error `Decode
                 | Some a ->
-                    continue k (Ok a)
-    in
-    Event_target.add
-        "loadend"
-        handler
-        (Http_request.event_target req)
+                    Ok a
+    end
+
+
+    let request
+        (meth: string)
+        (url: string)
+        (headers: (string * string) list)
+        (body : Body.t)
+        (expect : 'a Expect.t)
+        : ('a, Error.t) t
+        =
+        fun _ k ->
+        let req = Http_request.make meth url headers body in
+        let handler _ =
+            assert (Http_request.ready_state req = 4);
+            let status = Http_request.status req in
+            if status >= 300 then (* not ok *)
+                continue k (Error (`Status status))
+            else
+                continue k (expect req)
+        in
+        Event_target.add
+            "loadend"
+            handler
+            (Http_request.event_target req)
+
+
+    let text
+            (meth: string)
+            (url: string)
+            (headers: (string * string) list)
+            (body: string)
+        : (string, Error.t) t
+        =
+        request meth url headers (Body.string body) Expect.string
+
+
+    let json
+            (meth: string)
+            (url: string)
+            (headers: (string * string) list)
+            (body: Base.Value.t option)
+            (decode: 'a Base.Decode.t)
+        : ('a, Error.t) t
+        =
+        let body =
+            match body with
+            | None ->
+                Body.empty
+            | Some b ->
+                Body.json b
+        in
+        request meth url headers body (Expect.json decode)
+end
+
 
 
 let now: (Time.t, 'e) t =

--- a/src/examples/browser/webapp.ml
+++ b/src/examples/browser/webapp.ml
@@ -42,7 +42,7 @@ end
 
 module Http =
 struct
-    type error = Task.http_error
+    type error = Task.Http.Error.t
 
     type res = (string, error) result
 end
@@ -401,11 +401,11 @@ let http_page: page =
     let view state =
         let open Html in
         let view_error = function
-            | `Http_status status ->
+            | `Status status ->
                 text ("error: http status = " ^ string_of_int status)
-            | `Http_no_json ->
+            | `No_json ->
                 text "error: invalid json"
-            | `Http_decode ->
+            | `Decode ->
                 text "error: cannot decode javascript object"
         in
         let view_http_text =
@@ -436,7 +436,7 @@ let http_page: page =
             http_text
             Task.(
                 let* _ = sleep 1000 () in
-                http_text "GET" url [] ""
+                Http.text "GET" url [] ""
             )
     and cmd2 =
         let decode =
@@ -453,7 +453,7 @@ let http_page: page =
             http_json
             Task.(
                 let* _ = sleep 2000 () in
-                http_json "GET" url [] "" decode
+                Http.json "GET" url [] None decode
             )
     in
     Page.make


### PR DESCRIPTION
While trying out ``fmlib_browser`` I realized that there is no easy way to send HTTP requests with JSON bodies.

``http_json`` takes a string as its ``body`` argument. The ``Value`` module allows constructing JSON values, but has no ``to_string`` function. So to send JSON bodies right now I have to construct JSON strings manually.

I see two alternatives for solving this:

1. Add a ``to_string`` function to module ``Value``

2. Change ``http_json`` so it accepts a ``Value.t option`` as its ``body`` argument

I implemented 2. because it gives us the more convenient and type-safe API. Also, I would argue that sending *and* receiving JSON is a very common use case (much more common that sending text and receiving JSON).

It is a breaking change though.