### PR TITLE
add Content-Type headers automatically

### DIFF
--- a/src/browser/fmlib_browser.mli
+++ b/src/browser/fmlib_browser.mli
@@ -1112,19 +1112,21 @@ sig
             type t
 
             val empty : t
-            (** The body will be empty. This is equivalent to [string ""]. *)
+            (** The body will be empty. *)
 
-            val string : string -> t
-            (** [string s]
+            val string : string -> string -> t
+            (** [string media_type s]
 
-                The body will be the string [s]. This corresponds to media type
-                [text/plain]. *)
+                The body will be the string [s]. The [Content-Type] header
+                will be automatically set to the given [media_type]. For common
+                media types, a.k.a. MIME types, see
+                {{: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types } this list}. *)
 
             val json : Value.t -> t
             (** [json v]
 
-                The body will be [v], encoded as json. This corresponds to media
-                type [application/json]. *)
+                The body will be [v], encoded as json. The [Content-Type] header
+                will be automatically set to [application/json]. *)
 
         end
 
@@ -1134,15 +1136,14 @@ sig
             type 'a t
 
             val string : string t
-            (** The response is expected to be a string. This corresponds to
-                media type [text/plain]. *)
+            (** The response is expected to be a string and will not be decoded
+                further. *)
 
             val json : 'a Decoder.t -> 'a t
             (** [json decoder]
 
                 The response is expected to be json and will be decoded with
-                [decoder]. This corresponds to media type
-                [application/json]). *)
+                [decoder]. *)
         end
 
 
@@ -1188,7 +1189,8 @@ sig
 
             Method is one of [GET, POST, DELETE, ... ].
 
-            The headers and the body can be empty.
+            The headers and the body can be empty. The [Content-Type] header
+            is automatically set to [text/plain].
 
             Example:
             {[
@@ -1216,7 +1218,8 @@ sig
             optional json value as the [body]. Expect a json value as the
             response which will be decoded by [decoder].
 
-            The headers can be empty.
+            The [headers] can be empty. The [Content-Type] header is
+            automatically set to [application/json] if [body] is not [None].
 
             Example:
             {[

--- a/src/browser/task.ml
+++ b/src/browser/task.ml
@@ -191,21 +191,30 @@ struct
 
     module Body =
     struct
-        type t = string
+        type t = {
+            contents : string;
+            media_type : string option;
+        }
 
-        let empty : t = ""
+        let empty : t =
+            { contents = ""; media_type = None }
 
-        let string (s : string) : t = s
+        let string (media_type : string) (s : string) : t =
+            { contents = s; media_type = Some media_type }
 
         let json (v : Base.Value.t) : t =
-            (* it's ok to call Option.get here because v is constructed with one of
-               the functions from Fmlib_browser.Value and thus is guaranteed to be
-               serializable *)
-            v
-            |> Base.Value.stringify
-            |> Option.get
-            |> Base.Decode.string
-            |> Option.get
+            {
+                (* it's ok to call Option.get here because v is constructed with
+                   one of the functions from Fmlib_browser.Value and thus is
+                   guaranteed to be serializable *)
+                contents =
+                    v
+                    |> Base.Value.stringify
+                    |> Option.get
+                    |> Base.Decode.string
+                    |> Option.get;
+                media_type = Some "application/json"
+            }
     end
 
 
@@ -240,7 +249,14 @@ struct
         : ('a, error) t
         =
         fun _ k ->
-        let req = Http_request.make meth url headers body in
+        let headers =
+            match body.media_type with
+            | None ->
+                headers
+            | Some c ->
+                ("Content-Type", c) :: headers
+        in
+        let req = Http_request.make meth url headers body.contents in
         let handler _ =
             assert (Http_request.ready_state req = 4);
             let status = Http_request.status req in
@@ -262,7 +278,7 @@ struct
             (body: string)
         : (string, error) t
         =
-        request meth url headers (Body.string body) Expect.string
+        request meth url headers (Body.string "text/plain" body) Expect.string
 
 
     let json


### PR DESCRIPTION
I implemented adding ``Content-Type`` headers automatically, based on the given body.

I decided against adding ``Accept`` headers for now because I think it happens quite often, that a user doesn't care about the response payload (or plays around with an API, not knowing what the response will look like). Automatic ``Accept`` headers would add an unnecessary restriction in those cases. ``elm/http`` doesn't add ``Accept`` headers either by the way.

I added an additional argument ``media_type`` to ``Body.string`` (like [stringBody](https://package.elm-lang.org/packages/elm/http/latest/Http#stringBody) in ``elm/http``). The general ``Http.request``thus forces the user to be explicit about the body contents. The convenience function ``Http.text`` sets the ``Content-Type`` automatically to what I believe is the most common value: ``text/plain``.