### PR TITLE
support file selection and reading a file into a string

### DIFF
--- a/src/browser/command.ml
+++ b/src/browser/command.ml
@@ -118,6 +118,10 @@ let time_zone (f: Time.Zone.t -> 'm): 'm t =
     perform Task.(map f time_zone)
 
 
+let file_text (file: File.t) (f: (string, Task.read_failed) result -> 'm): 'm t =
+    attempt f (Task.file_text file)
+
+
 let send_to_javascript (v: Base.Value.t): 'm t =
     just_do Task.(send_to_javascript v)
 

--- a/src/browser/fmlib_browser.ml
+++ b/src/browser/fmlib_browser.ml
@@ -53,6 +53,17 @@ end
 
 
 
+module File =
+struct
+    include Fmlib_js.File
+end
+
+
+
+
+
+
+
 module Decoder =
 struct
     include Fmlib_js.Base.Decode
@@ -122,6 +133,10 @@ struct
 
     let on_keyup (f: string -> 'm): 'm t =
         on "keyup" (decode_key_event f)
+
+
+    let on_fileselect (f: File.t list -> 'm): 'm t =
+        on "change" Decoder.(map f (field "target" (field "files" file_list)))
 
 
     (* Styles *)

--- a/src/examples/browser/dune
+++ b/src/examples/browser/dune
@@ -107,3 +107,19 @@
   (mode (promote (until-clean)))
   (action (copy spreadsheet.bc.js spreadsheet.js))
 )
+
+
+
+
+(executable
+  (name file_select)
+  (modules file_select)
+  (modes js)
+  (libraries fmlib_browser)
+)
+
+(rule
+  (targets file_select.js) (deps file_select.bc.js)
+  (mode (promote (until-clean)))
+  (action (copy file_select.bc.js file_select.js))
+)

--- a/src/examples/browser/file_select.html
+++ b/src/examples/browser/file_select.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script type="text/javascript" src="file_select.js">
+  </script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/src/examples/browser/file_select.ml
+++ b/src/examples/browser/file_select.ml
@@ -1,0 +1,122 @@
+open Fmlib_browser
+
+
+(* STATE AND MESSAGES *)
+
+type state = {
+    file: File.t option;
+    file_contents: (string option, string) result;
+}
+
+
+type msg =
+    | Selected_file of File.t
+    | Got_file_contents of string
+    | Got_error of string
+
+
+let init: state =
+    { file = None; file_contents = Ok None }
+
+
+
+
+(* UPDATE *)
+
+let update (state: state) (msg: msg): state * msg Command.t =
+    match msg with
+    | Selected_file file ->
+        let cmd = Command.file_text file (fun t ->
+            match t with
+            | Ok t ->
+                Got_file_contents t
+            | Error _ ->
+                Got_error "Failed to read file")
+        in
+        ({ state with file = Some file }, cmd)
+
+    | Got_file_contents contents ->
+        ({ state with file_contents = Ok (Some contents) }, Command.none)
+
+    | Got_error err ->
+        ({ state with file_contents = Error err }, Command.none)
+
+
+
+
+(* VIEW*)
+
+let view_select_button: msg Html.t =
+    let open Html in
+    let open Attribute in
+    input
+        [
+            attribute "type" "file";
+            attribute "accept" "text/plain";
+            on_fileselect (fun files -> Selected_file (List.hd files))
+        ]
+        [ text "Select file" ]
+
+
+let view_file_info (file: File.t): msg Html.t =
+    let open Html in
+    let open Attribute in
+    p [ color "green" ] [
+        text (
+            Printf.sprintf
+                "You selected file \"%s\", media type: %s, size: %i bytes"
+                (File.name file)
+                (File.media_type file |> Option.value ~default:"unknown")
+                (File.size file)
+        )
+    ]
+
+
+let view (state: state): msg Html.t * string =
+    let open Html in
+    let open Attribute in
+    let title = "Select file" in
+    let html =
+        div []
+            [
+                h1 [] [text "File selection"];
+                view_select_button;
+                h2 [] [text "File info"];
+                (
+                    match state.file with
+                    | None ->
+                        p [ color "grey" ]
+                            [ text "File info will be displayed here"]
+                    | Some file ->
+                        view_file_info file
+                );
+                h2 [] [text "File contents"];
+                (
+                    match state.file_contents with
+                    | Error err ->
+                        p [ color "red" ] [ text err ]
+                    | Ok None ->
+                        p [ color "grey" ]
+                            [ text "File contents will be displayed here" ]
+                    | Ok (Some s) ->
+                        pre [] [ text s ]
+                )
+            ]
+    in
+    (html, title)
+
+
+
+
+(* SUBSCRIPTIONS *)
+
+let subscriptions (_state: state): msg Subscription.t =
+    Subscription.none
+
+
+
+
+(* RUN *)
+
+let _ =
+    basic_application init Command.none view subscriptions update

--- a/src/js/base.ml
+++ b/src/js/base.ml
@@ -1,3 +1,5 @@
+type file = File.t
+
 open Js_of_ocaml
 open Fmlib_std
 
@@ -82,6 +84,11 @@ struct
     let is_number (v: Value.t): bool =
         Js.(typeof v == str_number)
 
+    let is_file (v: Value.t): bool =
+        Js.(instanceof v (Unsafe.global##.File))
+
+    let is_file_list (v: Value.t): bool =
+        Js.(instanceof v (Unsafe.global##.FileList))
 
     type 'a t = Value.t -> 'a option
 
@@ -222,6 +229,25 @@ struct
         map Option.return decode
         </>
         null None
+
+
+    let file: file t =
+        fun obj ->
+        if is_file obj then
+            Some (Obj.magic obj)
+        else
+            None
+
+
+    let file_list: file list t =
+        fun obj ->
+        if is_file_list obj then
+            Js.Unsafe.global##._Array##from obj
+            |> array file
+            |> Option.map Array.to_list
+        else
+            None
+
 
 end
 

--- a/src/js/base.mli
+++ b/src/js/base.mli
@@ -306,6 +306,10 @@ sig
             (option int) (Value.string "a") ~>      None
         ]}
     *)
+
+    val file_list:  File.t list t
+    (** Decode a javascript [FileList] object into an ocaml list of [File.t]. *)
+
 end
 
 

--- a/src/js/file.ml
+++ b/src/js/file.ml
@@ -1,0 +1,21 @@
+open Js_of_ocaml
+
+
+type t = File.file Js.t
+
+
+let name (file: t): string =
+    file##.name |> Js.to_string
+
+
+let media_type (file: t): string option =
+    match file##._type |> Js.to_string with
+    | "" ->
+        None
+    | s ->
+        Some s
+
+  
+let size (file: t): int =
+    file##.size
+

--- a/src/js/file.mli
+++ b/src/js/file.mli
@@ -1,0 +1,23 @@
+(** The javascript file object *)
+
+(**
+    The javascript file object represents a user-selected file in the local
+    filesystem. For example, when the user clicks on an [<input type="file">]
+    element and the [changed] event is fired, the [files] property of that
+    element can be decoded into a list of files using the
+    {!Base.Decode.file_list} decoder.
+  *)
+
+type t
+
+
+val name: t -> string
+(** The filename. *)
+
+
+val media_type: t -> string option
+(** The media type, a.k.a. MIME type, or [None] if it is unknown. *)
+
+
+val size: t -> int
+(** The file size in bytes. *)

--- a/src/js/file_reader.ml
+++ b/src/js/file_reader.ml
@@ -1,0 +1,44 @@
+type file = File.t
+
+
+open Js_of_ocaml
+
+
+class type fileReader =
+object
+    method readyState: int Js.readonly_prop
+
+    method readAsText: file -> unit Js.meth
+
+    method error: File.fileError Js.t Js.opt Js.readonly_prop
+
+    method result: Base.Value.t Js.readonly_prop
+end
+
+
+type t = fileReader Js.t
+
+
+let event_target (reader: t): Event_target.t =
+    Obj.magic reader
+
+
+let make: t =
+    let reader = Js.Unsafe.global##.FileReader in
+    new%js reader
+
+
+let ready_state (reader: t): int =
+    reader##.readyState
+
+
+let read_text (reader: t) (file: file) (): unit =
+    reader##readAsText file
+
+
+let result (reader: t): Base.Value.t option =
+    match reader##.error |> Js.Opt.to_option with
+    | None ->
+        Some (reader##.result)
+    | Some _ ->
+        None

--- a/src/js/file_reader.mli
+++ b/src/js/file_reader.mli
@@ -1,0 +1,39 @@
+(** The javascript file reader object *)
+
+type t
+(** The type of the file reader. *)
+
+
+val event_target: t -> Event_target.t
+(** View the file reader as an event target.
+
+    For reading the contents of a file into memory, an event handler for the
+    [loadend] event has to be registered and a read function, e.g. {!read_text}
+    has to be called. The handler can then obtain the file contents by calling
+    {!result} and decode them using one of the following decoders:
+
+    - {!Base.Decode.string}, if {!read_text} was used
+*)
+
+
+val make: t
+(** Create a file reader. *)
+
+
+val ready_state: t -> int
+(** Ready state of the read operation.
+
+    {[
+        0: empty
+        1: loading
+        2: done
+    ]}
+*)
+
+
+val read_text: t -> File.t -> unit -> unit
+(** Read the file contents into a string. *)
+
+
+val result: t -> Base.Value.t option
+(** The result of the read operation or [None] if an error occurred. *)

--- a/src/js/fmlib_js.mli
+++ b/src/js/fmlib_js.mli
@@ -23,6 +23,10 @@ module Event = Event
 
 module Event_target = Event_target
 
+module File = File
+
+module File_reader = File_reader
+
 module Http_request = Http_request
 
 module Web_worker = Web_worker


### PR DESCRIPTION
Hi Helmut,

I implemented what we discussed in #14.

Some notes:

- I think instead of the ``Decoder.file`` function you suggested, we need ``Decoder.file_list`` because the [File API](https://developer.mozilla.org/en-US/docs/Web/API/File) only gives us a [FileList](https://developer.mozilla.org/en-US/docs/Web/API/FileList) object which for historical reasons is *not* an array, but a different interface
- For reading the contents of a file, we need a task because the [FileReader](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) interface is asynchronous. I added a module ``Tasks.File`` in addition to the top-level ``File`` module (containing the type definition and property accessors). This made the most sense to me but I'm open to suggestions.
- I implemented the convenience function ``Attribute.on_fileselect`` as you suggested. I think this is definitely necessary because I find it non-obvious how to obtain files otherwise. It took me a while to understand how to write the underlying decoder in a nice way.
- The ``File_reader`` module is a separate top-level module in ``Fmlib_js``. Initially I wanted to put it into the ``File`` module (``File.Reader``) but that didn't work because of a dependency cycle (``Base`` > ``File`` > ``Event_target`` > ``Event`` > ``Base``). Maybe you have a better idea?

Looking forward to your review.

Cheers, Christian