### PR TITLE
implement Task.Http.Body.file

### DIFF
--- a/src/browser/http.ml
+++ b/src/browser/http.ml
@@ -5,29 +5,34 @@ type error = [ `Status of int | `No_json | `Decode ]
 
 module Body =
 struct
+    type contents = String of string | File of File.t
+
     type t = {
-        contents : string;
+        contents : contents;
         media_type : string option;
     }
 
     let empty : t =
-        { contents = ""; media_type = None }
+        { contents = String ""; media_type = None }
 
     let string (media_type : string) (s : string) : t =
-        { contents = s; media_type = Some media_type }
+        { contents = String s; media_type = Some media_type }
 
     let json (v : Value.t) : t =
-        {
-            (* it's ok to call Option.get here because v is constructed with
-               one of the functions from Fmlib_browser.Value and thus is
-               guaranteed to be serializable *)
-            contents =
-                v
-                |> Value.stringify
-                |> Decoder.string
-                |> Option.get;
-            media_type = Some "application/json"
-        }
+        (* it's ok to call Option.get here because v is constructed with one of
+           the functions from Fmlib_browser.Value and thus is guaranteed to be
+           serializable *)
+        let json =
+            v
+            |> Base.Value.stringify
+            |> Option.get
+            |> Base.Decode.string
+            |> Option.get
+        in
+        { contents = String json; media_type = Some "application/json" }
+
+    let file (file: File.t): t =
+        { contents = File file; media_type = File.media_type file }
 end
 
 

--- a/src/browser/http_intf.ml
+++ b/src/browser/http_intf.ml
@@ -36,13 +36,13 @@ sig
             media types, a.k.a. MIME types, see
             {{: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types } this list}. *)
 
-        val json : Value.t -> t
+        val json : value -> t
         (** [json v]
 
             The body will be [v], encoded as json. The [Content-Type] header
             will be automatically set to [application/json]. *)
 
-        val file : File.t -> t
+        val file : file -> t
         (** [file f]
             The body will be the contents of file [f]. If the media type of [f]
             can be determined using {!File.media_type}, the [Content-Type]
@@ -59,7 +59,7 @@ sig
         (** The response is expected to be a string and will not be decoded
             further. *)
 
-        val json : 'a Decoder.t -> 'a t
+        val json : 'a decoder -> 'a t
         (** [json decoder]
 
             The response is expected to be json and will be decoded with

--- a/src/browser/http_intf.ml
+++ b/src/browser/http_intf.ml
@@ -42,6 +42,12 @@ sig
             The body will be [v], encoded as json. The [Content-Type] header
             will be automatically set to [application/json]. *)
 
+        val file : File.t -> t
+        (** [file f]
+            The body will be the contents of file [f]. If the media type of [f]
+            can be determined using {!File.media_type}, the [Content-Type]
+            header will be automatically set to that media type. *)
+
     end
 
 

--- a/src/browser/task.ml
+++ b/src/browser/task.ml
@@ -224,7 +224,13 @@ let http_request
         | Some c ->
             ("Content-Type", c) :: headers
     in
-    let req = Http_request.make meth url headers body.contents in
+    let req =
+        match body.contents with
+        | String s ->
+            Http_request.make_text meth url headers s
+        | File f ->
+            Http_request.make_file meth url headers f
+    in
     let handler _ =
         assert (Http_request.ready_state req = 4);
         let status = Http_request.status req in

--- a/src/js/http_request.ml
+++ b/src/js/http_request.ml
@@ -1,6 +1,10 @@
+type file = File.t
+
 open Js_of_ocaml
 
 type js_string = Js.js_string Js.t
+
+type blob = File.blob Js.t
 
 class type xmlHttpRequest =
 object
@@ -9,6 +13,8 @@ object
     method setRequestHeader: js_string -> js_string -> unit Js.meth
 
     method send_string: js_string -> unit Js.meth
+
+    method send_blob: blob -> unit Js.meth
 
     method readyState: int Js.readonly_prop
     (*
@@ -39,7 +45,6 @@ let make
         (_method: string)
         (url: string)
         (headers: (string * string) list)
-        (body: string)
     : t
     =
     let req: xmlHttpRequest Js.t =
@@ -53,7 +58,30 @@ let make
              req##setRequestHeader (Js.string name) (Js.string value)
         )
         headers;
-    req##send_string (Js.string body);
+    req
+
+
+let make_text
+        (_method: string)
+        (url: string)
+        (headers: (string * string) list)
+        (text: string)
+    : t
+    =
+    let req = make _method url headers in
+    req##send_string (Js.string text);
+    req
+
+
+let make_file
+        (_method: string)
+        (url: string)
+        (headers: (string * string) list)
+        (file: file)
+    : t
+    =
+    let req = make _method url headers in
+    req##send_blob (Obj.magic file);
     req
 
 

--- a/src/js/http_request.mli
+++ b/src/js/http_request.mli
@@ -38,9 +38,17 @@ val event_target: t -> Event_target.t
     ]}
 *)
 
-val make: string -> string -> (string * string) list -> string -> t
-(** [make method url headers body]
+val make_text: string -> string -> (string * string) list -> string -> t
+(** [make_text method url headers text]
 
+    Make an http request with the string [text] as payload.
+*)
+
+
+val make_file: string -> string -> (string * string) list -> File.t -> t
+(** [make_file method url headers file]
+
+    Make an http request with contents of [file] as payload.
 *)
 
 


### PR DESCRIPTION
I implemented ``Task.Http.Body.file`` for doing HTTP requests with ``File.t`` values as a bodies.

This is the simplest form of uploading files and calls the [send_blob](https://ocaml.org/p/js_of_ocaml/6.0.1/doc/Js_of_ocaml/XmlHttpRequest/class-type-xmlHttpRequest/index.html#method-send_blob) method under the hood. The traditional way, [as described in elm/http](https://package.elm-lang.org/packages/elm/http/latest/Http#multipartBody) is to send a file as part of a ``multipart/form-data`` body, which is required by some web servers. I would like to leave this for another PR.

I tested this with an [example app](https://github.com/royneary/fmlib_file_upload) using a dream backend. You can run it like this:

```
# I'm using dune package management, so a recent version of dune is needed
dune pkg lock
# this will start a webserver at http://localhost:8080
dune exec file_upload
```

This app uploads the selected file, expecting a json object with a URL from the server, then downloads the file from that URL and checks if the contents of the local file and the downloaded data are identical. The output should look like this:

- Selected file "test1.txt" (size: 6 bytes, media type: text/plain)
- File was uploaded successfully and is available at /files/test1.txt
- 6 bytes were downloaded
- File check: PASS