### PR TITLE
create a new FileReader object on each call to File_reader.make

### DIFF
--- a/src/browser/task.ml
+++ b/src/browser/task.ml
@@ -187,7 +187,7 @@ let time_zone: (Time.Zone.t, 'e) t =
 
 let file_text (file: File.t): (string, read_failed) t =
     fun _ k ->
-    let reader = File_reader.make in
+    let reader = File_reader.make () in
     File_reader.read_text reader file ();
     let handler _ =
         assert (File_reader.ready_state reader = 2);

--- a/src/js/file_reader.ml
+++ b/src/js/file_reader.ml
@@ -23,7 +23,7 @@ let event_target (reader: t): Event_target.t =
     Obj.magic reader
 
 
-let make: t =
+let make (): t =
     let reader = Js.Unsafe.global##.FileReader in
     new%js reader
 

--- a/src/js/file_reader.mli
+++ b/src/js/file_reader.mli
@@ -16,7 +16,7 @@ val event_target: t -> Event_target.t
 *)
 
 
-val make: t
+val make: unit -> t
 (** Create a file reader. *)
 
 


### PR DESCRIPTION
While working on #16 I found a bug in the code I introduced in #15.

It can be reproduced with the [example app](https://github.com/royneary/fmlib_file_upload) I wrote for testing #16.

When uploading the first file, everything works as expected. But when uploading the second file, the output is like this:

- Selected file "test2.txt" (size: 6 bytes, media type: text/plain)
- File was uploaded successfully and is available at /files/test2.txt
- 6 bytes were downloaded
- File check: FAIL
- File check: PASS

The file check is executed twice even though the application logic is correct.

This happens because ``File_reader.make`` has 0 arguments, so the body of the function will only ever get evaluated once and the ``FileReader`` object it creates is reused during the runtime of the application. This means, old event handlers that were registered when a file was read, will run again, when the next file is read.

Making it a real function by adding a ``unit`` argument fixes that.