### PR TITLE
implement a more flexible file selection mechanism

### DIFF
--- a/src/browser/attribute.ml
+++ b/src/browser/attribute.ml
@@ -61,10 +61,6 @@ let on_keyup (f: string -> 'm): 'm t =
     on "keyup" (decode_key_event f)
 
 
-let on_fileselect (f: File.t list -> 'm): 'm t =
-    on "change" Decoder.(map f (field "target" (field "files" file_list)))
-
-
 (* Styles *)
 
 let font_size (size: string): 'm t =

--- a/src/browser/attribute_intf.ml
+++ b/src/browser/attribute_intf.ml
@@ -119,29 +119,6 @@ sig
         Produce the message [f key] on the keyup event with [key].
     *)
 
-    val on_fileselect: (file list -> 'msg) -> 'msg t
-    (** [on_fileselect f]
-
-        Produce the message [f files] when a user selects one or more files.
-        [files] is guaranteed to have at least one element.
-
-        This only works on an {!Html.val-input} node with the [type="file"]
-        attribute. The [accept] attribute can be used to only show files with
-        specific media types in the file selection dialog. The [multiple]
-        attribute can be used to allow selecting multiple files at once.
-
-        E.g. to allow selecting multiple image files of type [png] or [jpeg]:
-        {[
-            input
-                [
-                    attribute "type" "file";
-                    attribute "accept" "image/png,image/jpeg";
-                    attribute "multiple" "true";
-                    on_fileselect (fun files -> Selected_files files)
-                ]
-                [ text "Select files" ]
-        ]}
-    *)
 
 
 

--- a/src/browser/command.ml
+++ b/src/browser/command.ml
@@ -118,6 +118,14 @@ let time_zone (f: Time.Zone.t -> 'm): 'm t =
     perform Task.(map f time_zone)
 
 
+let select_file (media_types: string list) (f: (File.t -> 'm)): 'm t =
+    perform Task.(map f (select_file media_types))
+
+
+let select_files (media_types: string list) (f: (File.t list -> 'm)): 'm t =
+    perform Task.(map f (select_files media_types))
+
+
 let file_text (file: File.t) (f: (string, Task.read_failed) result -> 'm): 'm t =
     attempt f (Task.file_text file)
 

--- a/src/browser/command_intf.ml
+++ b/src/browser/command_intf.ml
@@ -90,6 +90,29 @@ sig
 
     (** {2 File Operations} *)
 
+    val select_file: string list -> (file -> 'm) -> 'm t
+    (** [select_file media_types f]
+        Show the browser's file selection dialog and produce [f file] when the
+        user selected a file. The given list of [media_types] allows restricting
+        what file types are visible in the dialog (users can still select
+        different file types if they want to).
+
+        NOTE: This command only works if it is triggered in reaction to a user
+        event, such as a mouse click. This restriction is imposed by browsers
+        for security reasons (websites should not be able to ask for file access
+        without user interaction).
+    *)
+
+    val select_files: string list -> (file list -> 'm) -> 'm t
+    (** [select_files media_types f]
+        The same as {!select_file} but allows selecting multiple files at once.
+
+        NOTE: This command only works if it is triggered in reaction to a user
+        event, such as a mouse click. This restriction is imposed by browsers
+        for security reasons (websites should not be able to ask for file access
+        without user interaction).
+    *)
+
     val file_text: file -> ((string, read_failed) result -> 'm) -> 'm t
     (** [file_text file f]
 

--- a/src/browser/file_intf.ml
+++ b/src/browser/file_intf.ml
@@ -3,7 +3,8 @@ module type FILE =
 sig
 
     (** A file handle that represents a user-selected file in the local
-        filesystem. See {!Attribute.on_fileselect} on how to obtain file handles.
+        filesystem. See {!Command.select_file} and {!Command.select_files} on
+        how to obtain file handles.
     *)
 
     type t

--- a/src/browser/task_intf.ml
+++ b/src/browser/task_intf.ml
@@ -212,6 +212,29 @@ sig
 
     (** {1 File operations} *)
 
+    val select_file: string list -> (file, empty) t
+    (** [select_file media_types]
+        Show the browser's file selection dialog and return a file when the user
+        selected one. The given list of [media_types] allows restricting what
+        file types are visible in the dialog (users can still select different
+        file types if they want to).
+
+        NOTE: This task only works if it is triggered in reaction to a user
+        event, such as a mouse click. This restriction is imposed by browsers
+        for security reasons (websites should not be able to ask for file access
+        without user interaction).
+    *)
+
+    val select_files: string list -> (file list, empty) t
+    (** [select_files media_types]
+        The same as {!select_file} but allows selecting multiple files at once.
+
+        NOTE: This task only works if it is triggered in reaction to a user
+        event, such as a mouse click. This restriction is imposed by browsers
+        for security reasons (websites should not be able to ask for file access
+        without user interaction).
+    *)
+
     val file_text: file -> (string, read_failed) t
     (** [file_text file f]
 

--- a/src/examples/browser/file_select.ml
+++ b/src/examples/browser/file_select.ml
@@ -10,6 +10,7 @@ type state = {
 
 
 type msg =
+    | Clicked_select_file
     | Selected_file of File.t
     | Got_file_contents of string
     | Got_error of string
@@ -25,6 +26,11 @@ let init: state =
 
 let update (state: state) (msg: msg): state * msg Command.t =
     match msg with
+    | Clicked_select_file ->
+        let cmd =
+            Command.select_file ["text/plain"] (fun file -> Selected_file file)
+        in
+        (state, cmd)
     | Selected_file file ->
         let cmd = Command.file_text file (fun t ->
             match t with
@@ -45,18 +51,6 @@ let update (state: state) (msg: msg): state * msg Command.t =
 
 
 (* VIEW*)
-
-let view_select_button: msg Html.t =
-    let open Html in
-    let open Attribute in
-    input
-        [
-            attribute "type" "file";
-            attribute "accept" "text/plain";
-            on_fileselect (fun files -> Selected_file (List.hd files))
-        ]
-        [ text "Select file" ]
-
 
 let view_file_info (file: File.t): msg Html.t =
     let open Html in
@@ -80,7 +74,7 @@ let view (state: state): msg Html.t * string =
         div []
             [
                 h1 [] [text "File selection"];
-                view_select_button;
+                button [on_click Clicked_select_file] [ text "Select file" ];
                 h2 [] [text "File info"];
                 (
                     match state.file with


### PR DESCRIPTION
I implemented a slightly modified version of the file selection that I originally proposed in #14.

I removed ``Attribute.on_fileselect`` to only have one file selection mechanism (least user confusion).

I will resolve the merge conflict tomorrow.