### PR TITLE
implement Http.Expect.map

### DIFF
--- a/src/browser/command_intf.ml
+++ b/src/browser/command_intf.ml
@@ -183,9 +183,38 @@ sig
         -> 'm http_expect
         -> (http_error -> 'm)
         -> 'm t
-    (** [http_request method url headers body expect error]
+    (** [http_request method url headers body expect on_error]
 
-        Details see {!val:Task.http_request}
+        Make an http [method] request to [url] with [headers] and [body].
+        [expect] specifies the expected response format and can be used to
+        produce a message. [on_error] transforms a {!Http.error} into a
+        message.
+
+        Examples:
+        {[
+            (* Send an empty body and expect a string response *)
+            let on_success msg = Got_message msg in
+            let on_error _ = Got_error "Failed to obtain message" in
+            http_request
+                "GET"
+                "/message/123"
+                []
+                Http.Body.empty
+                (Http.Expect.map on_success Http.Expect.string)
+                on_error
+
+            (* Send file contents as the body and expect a json object with
+               field "url" *)
+            let on_success url = Got_file_uploaded url in
+            let on_error _ = Got_error "file upload failed" in
+            http_request
+                "PUT"
+                "/upload/my_file.txt"
+                []
+                (Http.Body.file file)
+                (Http.Expect.json Decoder.(map on_success (field "url" string)))
+                on_error
+        ]}
     *)
 
 

--- a/src/browser/http.ml
+++ b/src/browser/http.ml
@@ -54,4 +54,9 @@ struct
                 Error `Decode
             | Some a ->
                 Ok a
+
+    let map (f : ('a -> 'b)) (expect : 'a t): 'b t =
+        fun req ->
+        Result.map f (expect req)
+
 end

--- a/src/browser/http_intf.ml
+++ b/src/browser/http_intf.ml
@@ -70,6 +70,13 @@ sig
 
             The response is expected to be json and will be decoded with
             [decoder]. *)
+
+        val map : ('a -> 'b) -> 'a t -> 'b t
+        (** [map f expect]
+
+            Map the result of [expect] via the function [f] to produce a
+            message. This is meant to be used in combination with
+            {!Command.http_request}. *)
     end
 
 end

--- a/src/browser/task_intf.ml
+++ b/src/browser/task_intf.ml
@@ -260,7 +260,7 @@ sig
         [expect] specifies the expected response format.
 
         This is the most general http request function. See also the more
-        specific functions [text] and [json].
+        specific functions [http_text] and [http_json].
 
         Example:
         {[


### PR DESCRIPTION
While trying out the new function ``Command.http_request``, I couldn't find a way to pass ``Http.Expect.string`` and produce a message.

By adding ``Http.Expect.map``, that becomes possible:

``` ocaml
let on_success msg = Got_message msg in
let on_error _ = Got_error "Failed to obtain message" in
http_request
    "GET"
    "/message/123"
    []
    Http.Body.empty
    (Http.Expect.map on_success Http.Expect.string)
    on_error
```