### PR TITLE
URL API strongly inspired by elm/url

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
-(lang dune 1.10)
+(lang dune 1.11)
+
 (name fmlib)

--- a/src/browser/dune
+++ b/src/browser/dune
@@ -2,6 +2,8 @@
   (public_name fmlib_browser)
   (name fmlib_browser)
   (libraries fmlib_js)
+  (preprocess (pps ppx_inline_test))
+  (inline_tests (modes js))
 )
 
 

--- a/src/browser/fmlib_browser.ml
+++ b/src/browser/fmlib_browser.ml
@@ -3,6 +3,7 @@ module Time       = Time
 module Task       = Task
 module Value      = Value
 module Event_flag = Event_flag
+module Url        = Url
 module File       = File
 module Decoder    = Decoder
 module Http       = Http

--- a/src/browser/fmlib_browser.mli
+++ b/src/browser/fmlib_browser.mli
@@ -33,6 +33,7 @@ module File: File_intf.FILE
 
 module Event_flag: Event_flag_intf.FLAG
 
+module Url: Url_intf.URL
 
 
 

--- a/src/browser/handler.ml
+++ b/src/browser/handler.ml
@@ -1,4 +1,9 @@
-open Fmlib_js
+module Base = Fmlib_js.Base
+module Event = Fmlib_js.Event
+module Event_target = Fmlib_js.Event_target
+module Timer = Fmlib_js.Timer
+module Date = Fmlib_js.Date
+module Dom = Fmlib_js.Dom
 
 
 
@@ -294,11 +299,18 @@ struct
         let open Base.Decode in
         let* tag  = field "target" (field "tagName" string) in
         let* href = field "target" (field "href"    string) in
-        match Url.parse href with
+        match Url.of_string href with
         | None ->
             fail
         | Some url ->
-            if tag <> "A" || tag <> "a" || not (Url.is_page url) then
+            let is_page (url: Url.t) =
+                match Fmlib_js.Url.current () |> Url.of_string with
+                | Some current ->
+                    url.protocol = current.protocol && url.host = current.host
+                | None ->
+                    false
+            in
+            if tag <> "A" || tag <> "a" || not (is_page url) then
                 fail
             else
                 return url

--- a/src/browser/subscription.ml
+++ b/src/browser/subscription.ml
@@ -1,4 +1,4 @@
-open Fmlib_js
+module Base = Fmlib_js.Base
 
 type 'm t =
     | None

--- a/src/browser/subscriptions.ml
+++ b/src/browser/subscriptions.ml
@@ -1,4 +1,4 @@
-open Fmlib_js
+module Base = Fmlib_js.Base
 
 module String_map = Fmlib_std.Btree.Map (String)
 module Int_map  = Fmlib_std.Btree.Map (Int)

--- a/src/browser/url.ml
+++ b/src/browser/url.ml
@@ -1,30 +1,906 @@
-module Local =
-struct
-    type t
-
-    let string (_: t): string =
-        assert false (* nyi *)
-end
+type protocol = Http | Https
 
 
 type t =
-    | Raw of string
-    | Local of Local.t
+    {
+        protocol: protocol;
+        host: string;
+        port: int option;
+        path: string;
+        query: string option;
+        fragment: string option;
+    }
 
 
-let parse (str: string): t option =
-    Some (Raw str)
+let of_string (s: string): t option =
+    let take n s = String.sub s 0 n in
+    let drop n s = String.sub s n (String.length s - n) in
+    let chomp_before_path protocol fragment query path s =
+        if String.length s = 0 || String.contains s '@' then
+            None
+        else
+            match String.index_opt s ':' with
+            | None ->
+                Some {protocol; host = s; port = None; path; query; fragment}
+            | Some i ->
+                let host = take i s in
+                let port = int_of_string_opt (drop (i + 1) s) in
+                if String.length host > 0 && Option.is_some port then
+                    Some {protocol; host; port; path; query; fragment}
+                else
+                    None
+    in
+    let chomp_before_query protocol fragment query s =
+        match String.index_opt s '/' with
+        | None ->
+            chomp_before_path protocol fragment query "/" s
+        | Some i ->
+            let path = drop i s in
+            let rest = take i s in
+            chomp_before_path protocol fragment query path rest
+    in
+    let chomp_before_fragment protocol fragment s =
+        match String.index_opt s '?' with
+        | None ->
+            chomp_before_query protocol fragment None s
+        | Some i ->
+            let query = Some (drop (i + 1) s) in
+            let rest = take i s in
+            chomp_before_query protocol fragment query rest
+    in
+    let chomp_after_protocol protocol s =
+        match String.index_opt s '#' with
+        | None ->
+            chomp_before_fragment protocol None s
+        | Some i ->
+            let fragment = Some (drop (i + 1) s) in
+            let rest = take i s in
+            chomp_before_fragment protocol fragment rest
+    in
+    if String.starts_with ~prefix:"http://" s then
+        chomp_after_protocol Http (drop 7 s)
+    else if String.starts_with ~prefix:"https://" s then
+        chomp_after_protocol Https (drop 8 s)
+    else
+        None
 
 
-let string: t -> string =
-    function
-    | Raw str ->
-        str
-    | Local loc ->
-        Local.string loc
+let percent_encode_part (s: string): string =
+    Fmlib_js.Url.percent_encode_component s
 
-let is_page: t -> bool = function
-    | Raw _ ->
-        true (* MISSING!!! assert false *)
-    | Local _ ->
-        true
+
+let percent_decode_part (s: string): string option =
+    Fmlib_js.Url.percent_decode_component s
+
+
+module Builder =
+struct
+
+    type t = string
+
+
+    let raw (segment: string): t =
+        segment
+
+
+    let string (segment: string): t =
+        percent_encode_part segment
+
+
+    let int (segment: int): t =
+        string_of_int segment
+
+
+    module Query =
+    struct
+
+        type t = string * string
+
+
+        let raw (key: string) (value: string): t =
+            (key, value)
+
+
+        let string (key: string) (value: string): t =
+            (percent_encode_part key, percent_encode_part value)
+
+
+        let int (key: string) (value: int): t =
+            (percent_encode_part key, string_of_int value)
+
+    end
+
+
+    module Fragment =
+    struct
+
+        type t = string
+
+        let raw (x: string): t =
+            x
+
+        let string (x: string): t =
+            percent_encode_part x
+
+    end
+
+
+    type root = Absolute | Relative | Cross_origin of string
+
+
+    let encode_query (params: Query.t list): string =
+        match params with
+        | [] ->
+            ""
+        | params ->
+            let string_of_pair (k, v) = k ^ "=" ^ v in
+            "?" ^ (params |> List.map string_of_pair |> String.concat "&")
+
+
+    let encode_path (path: t list): string =
+        path |> String.concat "/"
+
+
+    let relative (path: t list) (query: Query.t list): string =
+        encode_path path ^ encode_query query
+
+
+    let absolute (path: t list) (query: Query.t list): string =
+        "/" ^ encode_path path ^ encode_query query
+
+
+    let cross_origin (pre_path: string) (path: t list) (query: Query.t list): string =
+        let path = if List.is_empty path then "" else "/" ^ encode_path path in
+        pre_path ^ path ^ encode_query query
+
+    let custom (root: root) (path: t list) (query: Query.t list) (fragment: Fragment.t option): string =
+        let fragment =
+            match fragment with
+            | None ->
+                ""
+            | Some f ->
+                "#" ^ f
+        in
+        match root with
+        | Absolute ->
+            (absolute path query) ^ fragment
+        | Relative ->
+            (relative path query) ^ fragment
+        | Cross_origin pre_path ->
+            (cross_origin pre_path path query) ^ fragment
+
+end
+
+
+module Parser =
+struct
+
+    type 'a state =
+        {
+            unvisited: string list;
+            params: string list Dictionary.t;
+            fragment: string option;
+            value: 'a;
+        }
+
+
+    type url = t
+
+
+    type ('a, 'b) t = 'a state -> 'b state list
+
+
+    let custom (func: string -> 'a option): (('a -> 'b), 'b) t =
+        fun state ->
+        match state.unvisited with
+        | [] ->
+            []
+        | next :: unvisited ->
+            begin
+                match func next with
+                | Some next_value ->
+                    let value = state.value next_value in
+                    [ {state with unvisited; value} ]
+                | None ->
+                    []
+            end
+
+
+    let string: (string -> 'a, 'a) t =
+        fun x -> custom percent_decode_part x
+
+
+    let int: (int -> 'a, 'a) t =
+        fun x -> custom int_of_string_opt x
+
+
+    let s_aux (s: string) (decode: string -> string option): ('a, 'a) t =
+        fun state ->
+        match state.unvisited with
+        | [] ->
+            []
+        | next :: unvisited ->
+            begin
+                match decode next with
+                | None ->
+                    []
+                | Some decoded ->
+                    if decoded = s then
+                        [ {state with unvisited } ]
+                    else
+                        []
+            end
+
+
+    let s (s: string): ('a, 'a) t =
+        s_aux s percent_decode_part
+
+
+    let (</>) (parser1: ('a, 'b) t) (parser2: ('b, 'c) t): ('a, 'c) t =
+        fun state ->
+        List.concat_map parser2 (parser1 state)
+
+
+    let map (sub_value: 'a) (p: ('a, 'b) t): (('b -> 'c), 'c) t =
+        let map_state f s =
+            {s with value = f s.value}
+        in
+        fun state ->
+        List.map (map_state state.value) (p {state with value = sub_value})
+
+
+    let one_of (parsers: ('a, 'b) t list): ('a, 'b) t =
+        fun state -> List.concat_map (fun p -> p state) parsers
+
+
+    let top: ('a, 'a) t =
+        fun state -> [state]
+
+
+    module Query =
+    struct
+
+        type 'a t = string list Dictionary.t -> 'a
+
+
+        let custom (key: string) (func: string list -> 'a): 'a t =
+            fun dict ->
+            func (Option.value ~default:[] (Dictionary.find_opt key dict))
+
+
+        let string (key: string): (string option) t =
+            let extract_result results =
+                match results with
+                | [result] ->
+                    percent_decode_part result
+                | _ ->
+                    None
+            in
+            custom key extract_result
+
+
+        let int (key: string): (int option) t =
+            let extract_result results =
+                match results with
+                | [result] ->
+                    int_of_string_opt result
+                | _ ->
+                    None
+            in
+            custom key extract_result
+
+
+        let enum (key: string) (table: (string * 'a) list): 'a option t =
+            let extract_result results =
+                let dict = Dictionary.of_list table in
+                match results with
+                | [result] ->
+                    begin
+                        match percent_decode_part result with
+                        | Some new_key ->
+                            Dictionary.find_opt new_key dict
+                        | None ->
+                            None
+                    end
+                | _ ->
+                    None
+            in
+            custom key extract_result
+
+
+        let map (f: 'a -> 'b) (p: 'a t): 'b t =
+            fun dict ->
+            f (p dict)
+
+
+        let map2 (f: 'a -> 'b -> 'c) (p1: 'a t) (p2: 'b t): 'c t =
+            fun dict ->
+            f (p1 dict) (p2 dict)
+
+
+        let map3
+                (f: 'a -> 'b -> 'c -> 'd)
+                (p1: 'a t)
+                (p2: 'b t)
+                (p3: 'c t)
+            : 'd t =
+            fun dict ->
+            f (p1 dict) (p2 dict) (p3 dict)
+
+
+        let map4
+                (f: 'a -> 'b -> 'c -> 'd -> 'e)
+                (p1: 'a t)
+                (p2: 'b t)
+                (p3: 'c t)
+                (p4: 'd t)
+            : 'e t =
+            fun dict ->
+            f (p1 dict) (p2 dict) (p3 dict) (p4 dict)
+
+
+        let map5
+                (f: 'a -> 'b -> 'c -> 'd -> 'e -> 'f)
+                (p1: 'a t)
+                (p2: 'b t)
+                (p3: 'c t)
+                (p4: 'd t)
+                (p5: 'e t)
+            : 'f t =
+            fun dict ->
+            f (p1 dict) (p2 dict) (p3 dict) (p4 dict) (p5 dict)
+
+
+        let map6
+                (f: 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g)
+                (p1: 'a t)
+                (p2: 'b t)
+                (p3: 'c t)
+                (p4: 'd t)
+                (p5: 'e t)
+                (p6: 'f t)
+            : 'g t =
+            fun dict ->
+            f (p1 dict) (p2 dict) (p3 dict) (p4 dict) (p5 dict) (p6 dict)
+
+
+        let map7
+                (f: 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h)
+                (p1: 'a t)
+                (p2: 'b t)
+                (p3: 'c t)
+                (p4: 'd t)
+                (p5: 'e t)
+                (p6: 'f t)
+                (p7: 'g t)
+            : 'h t =
+            fun dict ->
+            f (p1 dict) (p2 dict) (p3 dict) (p4 dict) (p5 dict) (p6 dict) (p7 dict)
+
+
+        let map8
+                (f: 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h -> 'i)
+                (p1: 'a t)
+                (p2: 'b t)
+                (p3: 'c t)
+                (p4: 'd t)
+                (p5: 'e t)
+                (p6: 'f t)
+                (p7: 'g t)
+                (p8: 'h t)
+            : 'i t =
+            fun dict ->
+            f (p1 dict) (p2 dict) (p3 dict) (p4 dict) (p5 dict) (p6 dict) (p7 dict) (p8 dict)
+
+    end
+
+
+    let query (query_parser: 'a Query.t): (('a -> 'b), 'b) t =
+        fun state ->
+        let value = state.value (query_parser state.params) in
+        [ {state with value} ]
+
+
+    let (<?>) (parser: ('a, ('b -> 'c)) t) (query_parser: 'b Query.t): ('a, 'c) t =
+        (</>) parser (query query_parser)
+
+
+    let fragment (func: string option -> 'a): (('a -> 'b), 'b) t =
+        fun state ->
+        let fragment = Option.bind state.fragment percent_decode_part in
+        let value = state.value (func fragment) in
+        [ {state with value} ]
+
+
+    let parse (parser: (('a -> 'a), 'a) t) (url: url): 'a option =
+        let prepare_path (path: string): string list =
+            let rec remove_final_empty segments =
+                match segments with
+                | [] ->
+                    []
+                | "" :: [] ->
+                    []
+                | segment :: rest ->
+                    segment :: remove_final_empty rest
+            in
+            match String.split_on_char '/' path with
+            | "" :: segments ->
+                remove_final_empty segments
+            | segments ->
+                remove_final_empty segments
+        in
+        let prepare_query (query: string option): (string list) Dictionary.t =
+            let add_param dict segment =
+                match String.split_on_char '=' segment with
+                | [raw_key; value] ->
+                    begin
+                        match percent_decode_part raw_key with
+                        | Some key ->
+                            Dictionary.set
+                                key
+                                (fun v -> value :: Option.value ~default:[] v)
+                                dict
+                        | None ->
+                            dict
+                    end
+                | _ ->
+                    dict
+            in
+            match query with
+            | None ->
+                Dictionary.empty
+            | Some q ->
+                List.fold_left
+                    add_param
+                    Dictionary.empty
+                    (String.split_on_char '&' q)
+        in
+        let state =
+            {
+                unvisited = prepare_path url.path;
+                params = prepare_query url.query;
+                fragment = url.fragment;
+                value = Fun.id;
+            }
+        in
+        parser state
+        |> List.find_opt (fun s -> s.unvisited = [] || s.unvisited = [""])
+        |> Option.map (fun s -> s.value)
+
+end
+
+
+(* TESTS *)
+
+let%test "protocol" =
+    [
+        ("http://example", Http);
+        ("https://example", Https);
+    ]
+    |> List.map (fun (input, proto) -> (Option.get (of_string input), proto))
+    |> List.for_all (fun (url, proto) -> url.protocol = proto)
+
+
+let%test "host" =
+    [
+        ("http://example", "example");
+        ("http://приме́р", "приме́р");
+        ("http://127.0.0.1", "127.0.0.1")
+    ]
+    |> List.map (fun (input, host) -> (Option.get (of_string input), host))
+    |> List.for_all (fun (url, host) -> url.host = host)
+
+
+let%test "port" =
+    [
+        ("http://example", None);
+        ("http://example:443", Some 443);
+        ("http://example:0", Some 0);
+        ("http://example:65535", Some (65535));
+    ]
+    |> List.map (fun (input, port) -> (Option.get (of_string input), port))
+    |> List.for_all (fun (url, port) -> url.port = port)
+
+
+let%test "path" =
+    [
+        ("http://example", "/");
+        ("http://example/", "/");
+        ("http://example/a/b/c", "/a/b/c");
+    ]
+    |> List.map (fun (input, path) -> (Option.get (of_string input), path))
+    |> List.for_all (fun (url, path) -> url.path = path)
+
+
+let%test "query" =
+    [
+        ("http://example", None);
+        ("http://example?", Some "");
+        ("http://example?x=1&y=2", Some "x=1&y=2");
+    ]
+    |> List.map (fun (input, query) -> (Option.get (of_string input), query))
+    |> List.for_all (fun (url, query) -> url.query = query)
+
+
+let%test "fragment" =
+    [
+        ("http://example", None);
+        ("http://example#", Some "");
+        ("http://example#a", Some "a");
+    ]
+    |> List.map (fun (input, frag) -> (Option.get (of_string input), frag))
+    |> List.for_all (fun (url, frag) -> url.fragment = frag)
+
+
+let%test "invalid" =
+    [
+        "";
+        "http://";
+        "http:///";
+        "http://?";
+        "http://#";
+        "http://:443";
+        "test";
+        "/test";
+        "?test";
+        "#test";
+        "http://example:";
+        "http://example:a";
+        "http://user@example";
+        "file://test.txt";
+    ]
+    |> List.map of_string
+    |> List.for_all Option.is_none
+
+
+let%test "absolute" =
+    let open Builder in
+    [
+        (absolute [] [], "/");
+        (absolute [string "a"; string ""; string "b"] [], "/a//b");
+        (absolute [string "a"; int 123] [], "/a/123");
+        (absolute [] [Query.string "x" "1"], "/?x=1");
+        (absolute [] [Query.string "x" "1"; Query.int "y" 2], "/?x=1&y=2");
+    ]
+    |> List.for_all (fun (input, expected) -> input = expected)
+
+
+let%test "relative" =
+    let open Builder in
+    [
+        (relative [] [], "");
+        (relative [string "a"; string ""; string "b"] [], "a//b");
+        (relative [string "a"; int 123] [], "a/123");
+        (relative [] [Query.string "x" "1"], "?x=1");
+        (relative [] [Query.string "x" "1"; Query.int "y" 2], "?x=1&y=2");
+    ]
+    |> List.for_all (fun (input, expected) -> input = expected)
+
+
+let%test "cross-origin" =
+    let open Builder in
+    [
+        (cross_origin "http://example" [] [], "http://example");
+        (cross_origin "http://example" [string "a"; string ""; string "b"] [], "http://example/a//b");
+        (cross_origin "http://example" [string "a"; int 123] [], "http://example/a/123");
+        (cross_origin "http://example" [] [Query.string "x" "1"], "http://example?x=1");
+        (cross_origin "http://example" [] [Query.string "x" "1"; Query.int "y" 2], "http://example?x=1&y=2");
+    ]
+    |> List.for_all (fun (input, expected) -> input = expected)
+
+
+let%test "custom" =
+    let open Builder in
+    [
+        (
+            custom Absolute [] [] None,
+            "/"
+        );
+        (
+            custom Absolute [string "a"; string "b"] [Query.string "a" "b"] (Some (Fragment.string "test")),
+            "/a/b?a=b#test"
+        );
+        (
+            custom Relative [] [] None,
+            ""
+        );
+        (
+            custom Relative [string "a"; string "b"] [Query.string "a" "b"] (Some (Fragment.string "test")),
+            "a/b?a=b#test"
+        );
+        (
+            custom (Cross_origin "http://example") [] [] None,
+            "http://example"
+        );
+        (
+            custom (Cross_origin "http://example") [string "a"; string "b"] [Query.string "a" "b"] (Some (Fragment.string "test")),
+            "http://example/a/b?a=b#test"
+        );
+    ]
+    |> List.for_all (fun (input, expected) -> input = expected)
+
+
+let%test "percent-encode" =
+    let open Builder in
+    [
+        (
+            relative [string "a/b"] [],
+            "a%2Fb"
+        );
+        (
+            relative [string "имя"] [],
+            "%D0%B8%D0%BC%D1%8F"
+        );
+        (
+            relative [] [Query.string "a/b" "1/2"],
+            "?a%2Fb=1%2F2"
+        );
+        (
+            relative [] [Query.string "имя" "Гельмут"],
+            "?%D0%B8%D0%BC%D1%8F=%D0%93%D0%B5%D0%BB%D1%8C%D0%BC%D1%83%D1%82"
+        );
+        (
+            custom Relative [] [] (Some (Fragment.string "имя")),
+            "#%D0%B8%D0%BC%D1%8F"
+        );
+    ]
+    |> List.for_all (fun (input, expected) -> input = expected)
+
+
+let%test "raw unicode" =
+    let open Builder in
+    [
+        (relative [raw "имя"] [], "имя");
+        (relative [] [Query.raw "имя" "Гельмут"], "?имя=Гельмут");
+        (custom Relative [] [] (Some (Fragment.raw "имя")), "#имя");
+    ]
+    |> List.for_all (fun (input, expected) -> input = expected)
+
+
+let%test "path parsing" =
+    let open Parser in
+    let url = Option.get (of_string "http://example/test/123") in
+    [
+        (
+            map (fun s n -> `String_and_number (s, n)) (string </> int),
+            Some (`String_and_number ("test", 123))
+        );
+        (
+            map (fun n s -> `String_and_number (s, n)) (int </> string),
+            None
+        );
+        (
+            map (fun s -> `String s) (string),
+            None
+        );
+        (
+            map (fun n -> `Number n) (s "test" </> int),
+            Some (`Number 123)
+        );
+        (
+            map (fun n -> `Number n) (s "example" </> int),
+            None
+        );
+    ]
+    |> List.for_all (fun (parser, expected) -> parse parser url = expected)
+
+
+let%test "advanced path parsing" =
+    let open Parser in
+    let url = Option.get (of_string "http://example/test/123") in
+    [
+        (
+            map (fun s n -> `String_and_number (s, n)) (string </> int </> top),
+            Some (`String_and_number ("test", 123))
+        );
+        (
+            map (fun s -> `String s) (string </> top),
+            None
+        );
+        (
+            map (fun n -> `Number n) (one_of [s "example"; s "test"] </> int),
+            Some (`Number 123)
+        );
+        (
+            map (fun n -> `Number n) (one_of [s "example1"; s "example2"] </> int),
+            None
+        );
+        (
+            let nonempty_string s = if String.length s > 0 then Some s else None in
+            map (fun s n -> `String_and_number (s, n)) (custom nonempty_string </> int),
+            Some (`String_and_number ("test", 123))
+        );
+        (
+            let big_int s =
+                match int_of_string_opt s with
+                | Some n when n > 123 ->
+                    Some n
+                | _ ->
+                    None
+            in
+            map (fun s n -> `String_and_number (s, n)) (string </> custom big_int),
+            None
+        );
+    ]
+    |> List.for_all (fun (parser, expected) -> parse parser url = expected)
+
+
+let%test "unicode path parsing" =
+    let open Parser in
+    [
+        (
+            "http://example/%D0%B8%D0%BC%D1%8F",
+            map `Name (s "имя"),
+            Some `Name
+        );
+        (
+            "http://example/%D0%B8%D0%BC%D1%8F",
+            map (fun s -> `Other s) string,
+            Some (`Other "имя")
+        );
+        (
+            "http://example/%D0%B8%D0%BC%D1",
+            map (fun s -> `Other s) string,
+            None
+        );
+        (
+            "http://example/имя",
+            map `Name (s "имя"),
+            Some `Name
+        );
+        (
+            "http://example/имя",
+            map (fun s -> `Other s) string,
+            Some (`Other "имя")
+        );
+    ]
+    |> List.for_all
+        (fun (input, parser, expected) ->
+            parse parser (Option.get (of_string input)) = expected)
+
+
+let%test "query parsing" =
+    let open Parser in
+    let url = Option.get (of_string "http://example?a=test&b=123") in
+    [
+        (
+            top <?> Query.map (fun s -> `String s) (Query.string "a"),
+            Some (`String (Some "test"))
+        );
+        (
+            top <?> Query.map (fun n -> `Number n) (Query.int "b"),
+            Some (`Number (Some 123))
+        );
+        (
+            top <?> Query.map (fun s -> `String s) (Query.string "c"),
+            Some (`String None)
+        );
+        (
+            top <?> Query.map2 (fun s n -> `String_and_number (s, n)) (Query.string "a") (Query.int "b"),
+            Some (`String_and_number (Some "test", Some 123))
+        );
+        (
+            top <?> Query.map2 (fun n s -> `String_and_number (s, n)) (Query.int "b") (Query.string "a"),
+            Some (`String_and_number (Some "test", Some 123))
+        );
+    ]
+    |> List.for_all (fun (parser, expected) -> parse parser url = expected)
+
+
+let%test "advanced query parsing" =
+    let open Parser in
+    let url = Option.get (of_string "http://example?name=Xavier&year=1990&year=1996") in
+    [
+        (
+            let years strs =
+                strs
+                |> List.filter_map int_of_string_opt
+                |> List.sort compare
+            in
+            top <?> Query.map (fun xs -> `Years xs) (Query.custom "year" years),
+            Some (`Years [1990; 1996])
+        );
+        (
+            let table = [("Xavier", `OCaml); ("Simon", `Haskell)] in
+            top <?> Query.map (fun l -> `Language l) (Query.enum "name" table),
+            Some (`Language (Some `OCaml))
+        );
+    ]
+    |> List.for_all (fun (parser, expected) -> parse parser url = expected)
+
+
+let%test "unicode query parsing" =
+    let open Parser in
+    [
+        (
+            "http://example?%D0%B8%D0%BC%D1%8F=%D0%93%D0%B5%D0%BB%D1%8C%D0%BC%D1%83%D1%82",
+            top <?> Query.string "имя",
+            Some (Some "Гельмут")
+        );
+        (
+            "http://example?%D0%B8%D0%BC%D1=%D0%93%D0%B5%D0%BB%D1%8C%D0%BC%D1%83%D1%82",
+            top <?> Query.string "имя",
+            Some None
+        );
+        (
+            "http://example?%D0%B8%D0%BC%D1%8F=%D0%93%D0%B5%D0%BB%D1%8C%D0%BC%D1%83%D1",
+            top <?> Query.string "имя",
+            Some None
+        );
+        (
+            "http://example?имя=%D0%93%D0%B5%D0%BB%D1%8C%D0%BC%D1%83%D1%82",
+            top <?> Query.string "имя",
+            Some (Some "Гельмут")
+        );
+        (
+            "http://example?%D0%B8%D0%BC%D1%8F=Гельмут",
+            top <?> Query.string "имя",
+            Some (Some "Гельмут")
+        );
+        (
+            "http://example?имя=Гельмут",
+            top <?> Query.string "имя",
+            Some (Some "Гельмут")
+        );
+        (
+            "http://example?%D0%B8%D0%BC%D1%8F=%D0%93%D0%B5%D0%BB%D1%8C%D0%BC%D1%83%D1%82",
+            top <?> Query.enum "имя" [("Гельмут", "OCaml"); ("Simon", "Haskell")],
+            Some (Some "OCaml")
+        );
+        (
+            "http://example?имя=Гельмут",
+            top <?> Query.enum "имя" [("Гельмут", "OCaml"); ("Simon", "Haskell")],
+            Some (Some "OCaml")
+        );
+    ]
+    |> List.for_all
+        (fun (input, parser, expected) ->
+            parse parser (Option.get (of_string input)) = expected)
+
+
+let%test "fragment parsing" =
+    let open Parser in
+    [
+        (
+            "http://example",
+            top </> fragment Fun.id,
+            Some (None)
+        );
+        (
+            "http://example#",
+            top </> fragment Fun.id,
+            Some (Some "")
+        );
+        (
+            "http://example#test",
+            top </> fragment Fun.id,
+            Some (Some "test")
+        );
+    ]
+    |> List.for_all
+        (fun (input, parser, expected) ->
+            parse parser (Option.get (of_string input)) = expected)
+
+
+let%test "unicode fragment parsing" =
+    let open Parser in
+    [
+        (
+            "http://example#%D0%B8%D0%BC%D1%8F",
+            top </> fragment Fun.id,
+            Some (Some "имя")
+        );
+        (
+            "http://example#%D0%B8%D0%BC%D1",
+            top </> fragment Fun.id,
+            Some None
+        );
+        (
+            "http://example#имя",
+            top </> fragment Fun.id,
+            Some (Some "имя")
+        );
+    ]
+    |> List.for_all
+        (fun (input, parser, expected) ->
+            parse parser (Option.get (of_string input)) = expected)

--- a/src/browser/url_intf.ml
+++ b/src/browser/url_intf.ml
@@ -1,0 +1,908 @@
+module type URL =
+sig
+    (** Construct and parse URLs. *)
+
+
+    (** {1 Basics} *)
+
+    (** The protocol (a.k.a. scheme) of the URL. Only web-related protocols are
+        supported. *)
+    type protocol = Http | Https
+
+
+    type t =
+        {
+            protocol: protocol;
+            host: string;
+            port: int option;
+            path: string;
+            query: string option;
+            fragment: string option;
+        }
+    (** The parts of a URL.
+
+        The {{: https://tools.ietf.org/html/rfc3986 } URL spec} defines the
+        parts like this:
+        {[
+              https://example.com:8042/over/there?name=ferret#nose
+              \___/   \______________/\_________/ \_________/ \__/
+                |            |            |            |        |
+              scheme     authority       path        query   fragment
+        ]}
+
+        The strings in this type are not transformed in any way yet. The
+        {!Parser} module has functions for that, e.g. splitting the path into
+        segments, accessing specific query parameters and decoding the results
+        into custom data types.
+
+        Other parts of this library like {!Command.http_request} require URLs as
+        strings. Those should be constructed directly using functions from the
+        {!Builder} module, e.g {!Builder.absolute} or {!Builder.custom}.
+
+        NOTE: Not all URL features from the URL spec are supported. For example,
+        the [userinfo] segment as part of the [authority] is not supported.
+    *)
+
+
+    val of_string: string -> t option
+    (** [of_string s] tries to split [s] into its URL parts.
+
+        Examples:
+
+        {[
+            of_string "http://example.com:443"
+            =
+            Some
+                {
+                    protocol = Http;
+                    host = "example.com";
+                    port = Some 443;
+                    path = "/";
+                    query = None;
+                    fragment = None;
+                }
+
+            of_string "https://example.com/hats?q=top%20hat"
+            =
+            Some
+                {
+                    protocol = Https;
+                    host: "example.com";
+                    port = None;
+                    path = "/hats";
+                    query = Some "q=top%20hat";
+                    fragment = None;
+                }
+
+            of_string "example.com:443" = None (* no protocol *)
+
+            of_string "http://tom@example.com" = None (* userinfo not allowed *)
+
+            of_string "http://#cats" = None (* no host *)
+        ]}
+    *)
+
+
+    (** {1 Percent-encoding} *)
+
+    val percent_encode_part: string -> string
+    (** [percent_encode_part s] encodes a part of a URL by escaping special
+        characters like [?], [/] or non-ASCII characters. This uses
+        Javascript's {{: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent } encodeURIComponent}
+        internally.
+
+        Normally the {!Builder} module should be used for constructing URLs.
+        This function is here for exceptional cases that require more
+        control.
+    *)
+
+
+    val percent_decode_part: string -> string option
+    (** [percent_decode-part s] decodes a part of a URL recovering special
+        characters like [?], [/] or non-ASCII characters. This uses
+        Javascript's {{: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent } decodeURIComponent}
+        internally.
+
+        Normally the {!Parser} module should be used for decoding URLs. This
+        function is here for exceptional cases that require more control.
+    *)
+
+
+    (** {1 Builders and parsers }*)
+
+    module Builder:
+    sig
+        (** Construct URLs. *)
+
+
+        (** {1 Path builders } *)
+
+        type t
+        (** The path builder type *)
+
+
+        val raw: string -> t
+        (** [raw s] creates a URL path segment from string [s] without
+            percent-encoding it.
+
+            This is useful for including readable unicode graphemes in the URL
+            path. See {!absolute} for examples.
+        *)
+
+
+        val string: string -> t
+        (** [string s] creates a URL path segment from string [s].
+
+            Special characters like [?], [/] or non-ASCII characters will be
+            automatically escaped using percent-encoding. See {!absolute} for
+            examples.
+        *)
+
+
+        val int: int -> t
+        (** [int i] creates a URL path segment from the integer [i].
+
+            See {!absolute} for examples.
+        *)
+
+
+
+        (** {1 Query and fragment builders } *)
+
+        module Query:
+        sig
+            (** Construct queries *)
+
+            type t
+            (** The query builder type *)
+
+
+            val raw: string -> string -> t
+            (** [raw key s] creates a query parameter with the given [key]
+                and string value [s] without percent-encoding either.
+
+                This is useful for including readable unicode graphemes in the
+                URL query. See {!absolute} for examples.
+            *)
+
+
+            val string: string -> string -> t
+            (** [string key s] creates a query parameter with the given [key]
+                and string value [s]..
+
+                Special characters in the key and in the value, like [?], [/] or
+                non-ASCII characters will be automatically escaped using
+                percent-encoding. See {!absolute} for examples.
+            *)
+
+
+            val int: string -> int -> t
+            (** [int key i] creates a URL query parameter with the given [key]
+                and integer value [i].
+
+                See {!absolute} for examples.
+            *)
+
+        end
+
+
+        module Fragment:
+        sig
+            (** Construct fragments *)
+
+            type t
+            (** The fragment builder type *)
+
+
+            val raw: string -> t
+            (** [raw s] creates a URL fragment from string [s] without
+                percent-encoding it.
+
+                This is useful for including readable unicode graphemes in the URL
+                fragment.
+            *)
+
+
+            val string: string -> t
+            (** [string s] creates a URL path segment from string [s].
+
+                Special characters like [?], [/] or non-ASCII characters will be
+                automatically escaped using percent-encoding.
+            *)
+
+        end
+
+
+        (** {1 URL builders} *)
+
+        (** The type of custom URL we want to construct using {!custom} *)
+        type root =
+            | Absolute
+                (** A local URL starting with an absolute path. *)
+            | Relative
+                (** A local URL starting with a relative path (relative to the
+                    current location). *)
+            | Cross_origin of string
+                (** [Cross_origin origin] is a remote URL where the given
+                    [origin] is different from the current location. *)
+
+
+        val absolute: t list -> Query.t list -> string
+        (** [absolute path_segments query_parameters] constructs a local URL
+            (omitting the scheme and authority parts), containing the given
+            [path_segments] and [query_parameters].
+
+            Examples:
+
+            {[
+                absolute [] []
+                (* "/" *)
+
+                absolute [string "blog"; int 2025; int 8; int 7] []
+                (* "/blog/2025/8/7" *)
+
+                absolute [string "products"] [Query.string "search" "hat"; Query.int "page" 2]
+                (* "/products?search=hat&page=2" *)
+
+                absolute [string "name"; string "Гельмут"] []
+                (* "/name/%D0%93%D0%B5%D0%BB%D1%8C%D0%BC%D1%83%D1%82" *)
+
+                absolute [string "name"; raw "Гельмут"] []
+                (* "/name/Гельмут" *)
+
+                absolute [] [Query.string "emoji" "😅"]
+                (* "?emoji=%F0%9F%98%85" *)
+
+                absolute [] [Query.raw "emoji" "😅"]
+                (* "?emoji=😅" *)
+            ]}
+        *)
+
+
+        val relative: t list -> Query.t list -> string
+        (** [relative path_segments query_parameters] constructs a relative
+            local URL (relative the the current location), containing the given
+            [path_segments] and [query_parameters].
+
+            This behaves the same as {!absolute}, but omits the leading slash.
+
+            Examples:
+
+            {[
+                relative [] []
+                (* "" *)
+
+                relative [string "blog"; int 2025; int 8; int 7] []
+                (* "blog/2025/8/7" *)
+            ]}
+        *)
+
+
+        val cross_origin: string -> t list -> Query.t list -> string
+        (** [cross_origin pre_path path_segments query_parameters] allows
+            constructing a cross-origin URL, (a URL with a different host than
+            the current location), containing the given [path_segments] and
+            [query_parameters].
+
+            [pre_path] is inserted before the path as-is without further checks
+            or encoding.
+
+            Example:
+
+            {[
+                cross_origin "https://ocaml.org" [string "books"] []
+                (* "https://ocaml.org/books" *)
+            ]}
+        *)
+
+
+        val custom: root -> t list -> Query.t list -> Fragment.t option -> string
+        (** [custom root path_segments query_parameters fragment] allows
+            constructing custom URLs containing the given [path_segments],
+            [query_parameters] and [fragment].
+
+            Examples:
+
+            {[
+                custom
+                    Absolute
+                    [string "article"; int 42]
+                    [Query.string "search" "ocaml"]
+                    [Some Fragment.string "conclusion"]
+                (* "/article/42?search=ocaml#conclusion" *)
+
+                custom
+                    (Cross_origin "https://ocaml.org")
+                    [string "excercises"]
+                    []
+                    (Some Fragment.int 6)
+                (* "https://ocaml.org/excercises#6" *)
+            ]}
+        *)
+
+    end
+
+
+    module Parser:
+    sig
+
+        (** Parse URLs. *)
+
+
+
+        (** {1 Basics } *)
+
+        type url = t
+
+
+        type ('a, 'b) t
+        (** The URL parser type *)
+
+
+
+        (** {1 Path} *)
+
+        val string: (string -> 'a, 'a) t
+        (** [string] will parse a segment of the path as string.
+
+            The segment will be percent-decoded automatically.
+
+            {t | input                              | parse result     |
+               |------------------------------------|------------------|
+               | ["http://host/alice/"]             | [Some "alice"]   |
+               | ["http://host/bob"]                | [Some "bob"]     |
+               | ["http://host/%D0%91%D0%BE%D0%B1"] | [Some "Боб"]     |
+               | ["http://host/42/"]                | [Some "42"]      |
+               | ["http://host/"]                   | [None]           |}
+        *)
+
+
+        val int: (int -> 'a, 'a) t
+        (** [int] will parse a segment of the path as integer.
+
+            {t | input                  | parse result    |
+               |------------------------|-----------------|
+               | ["http://host/alice/"] | [None]          |
+               | ["http://host/bob"]    | [None]          |
+               | ["http://host/42/"]    | [Some "42"]     |
+               | ["http://host/"]       | [None]          |}
+        *)
+
+
+        val s: string -> ('a, 'a) t
+        (** [s str] will parse a segment of the path if it matches the given
+            string [str].
+
+            The segment will be percent-decoded automatically.
+
+            For example, the parser [s "blog" </> int] will behave as follows:
+
+            {t | input                   | parse result    |
+               |-------------------------|-----------------|
+               | ["http://host/blog/42"] | [Some 42]       |
+               | ["http://host/tree/42"] | [None]          |}
+        *)
+
+
+        val custom: (string -> 'a option) -> (('a -> 'b), 'b) t
+        (** [custom f] will parse a segment of the path by applying the
+            function [f] to the raw segment.
+
+            Example:
+
+            {[
+                let positive_int: (int -> 'a, 'a) Parser.t =
+                    Parser.custom @@
+                        fun s ->
+                            match int_of_string_opt s with
+                            | Some i when i > 0 ->
+                                Some i
+                            | _ ->
+                                None
+            ]}
+
+            The example parser produces the following results:
+
+            {t | input               | parse result    |
+               |---------------------|-----------------|
+               | ["http://host/0"]   | [None]          |
+               | ["http://host/-42"] | [None]          |
+               | ["http://host/42"]  | [Some 42]       |}
+        *)
+
+
+        val (</>): ('a, 'b) t -> ('b, 'c) t -> ('a, 'c) t
+        (** [p1 </> p2] combines the segment parsers [p1] and [p2] and returns
+            a new parser which will parse two path segments.
+
+            Example:
+
+            {[
+                let blog: (int -> 'a, 'a) Parser.t =
+                    let open Parser in
+                    s "blog" </> int
+            ]}
+
+            The example parser will behave like this:
+
+            {t | input                    | parse result    |
+               |--------------------------|-----------------|
+               | ["http://host/blog"]     | [None]          |
+               | ["http://host/blog/42"]  | [Some 42]       |
+               | ["http://host/blog/42/"] | [Some 42]       |}
+        *)
+
+
+        val map: 'a -> ('a, 'b) t -> (('b -> 'c), 'c) t
+        (** [map f parser] transforms the [parser] via [f].
+
+            [f] can be a function taking as many values as the parser
+            produces (see example 1) or, in case the parser produces no values
+            at all, [f] can be a variant constructor or a variant tag (see
+            example 2).
+
+            Examples 1:
+
+            {[
+                type date = {year: int; month: int; day: int}
+
+                let date_parser: (date -> 'a, 'a) Parser.t =
+                    let open Parser in
+                    map
+                        (fun year month day -> {year; month; day})
+                        (int </> int </> int)
+            ]}
+
+            The parser in example 1 will produce the following results:
+
+            {t | input                      | parse result                             |
+               |----------------------------|------------------------------------------|
+               | ["http://host/2025/08/"]   | [None]                                   |
+               | ["http://host/2025/08/07"] | [Some {year = 2025; month = 8; day = 7}] |}
+
+            Example 2:
+            {[
+                let language = Haskell | Ocaml | Rust
+
+                let language_parser: (language -> 'a, 'a) Parser.t =
+                    let open Parser in
+                    one_of
+                        [
+                            map Haskell (s "hs");
+                            map OCaml (s "ml");
+                            map Rust (s "rs");
+                        ]
+            ]}
+
+            The parser in example 2 will produce the following results:
+
+            {t | input              | parse result   |
+               |--------------------|----------------|
+               | ["http://host/hs"] | [Some Haskell] |
+               | ["http://host/ml"] | [Some OCaml]   |
+               | ["http://host/rs"] | [Some Rust]    |
+               | ["http://host/py"] | [None]         |}
+        *)
+
+
+        val one_of: ('a, 'b) t list -> ('a, 'b) t
+        (** [one_of parsers] runs the given [parsers] in the order they are
+            provided. The result is the result of the first succeeding parser or
+            [None] if all of them fail.
+
+            Example:
+            {[
+                type route =
+                    | Index
+                    | Article of int
+                    | Comment of {id: int; article_id: int}
+
+                let route_parser: (route -> 'a, 'a) Parser.t =
+                    let open Parser in
+                    one_of
+                        [
+                            map Index top;
+                            map (fun id -> Article id) (s "blog" </> int);
+                            map
+                                (fun article_id id -> Comment {id; article_id})
+                                (s "blog" </> int </> s "comment" </> int)
+                        ]
+            ]}
+
+            The example parser will behave like this:
+
+            {t | input                             | parse result                                |
+               |-----------------------------------|---------------------------------------------|
+               | ["http://host/"]                  | [Some Index]                                |
+               | ["http://host/blog"]              | [None]                                      |
+               | ["http://host/blog/42"]           | [Some (Article 42)]                         |
+               | ["http://host/blog/42"]           | [Some (Article 42)]                         |
+               | ["http://host/blog/42/comment"]   | [None]                                      |
+               | ["http://host/blog/42/comment/5"] | [Some (Comment {id = 5; article_id = 42}))] |}
+        *)
+
+
+        val top: ('a, 'a) t
+        (** [top] creates a parser that does not consume any path segment.
+
+            It can be used together with {!one_of} in order to use a common
+            prefix for multiple parsers:
+
+            {[
+                type route = Overview | Post of int
+
+                let blog: (route -> 'a, 'a) Parser.t =
+                    let open Parser in
+                    s "blog" </>
+                        one_of
+                            [
+                                map Overview top;
+                                map (fun id -> Post id) (s "post" </> int);
+                            ]
+            ]}
+
+            The example parser produces the following results:
+
+            {t | input                        | parse result     |
+               |------------------------------|------------------|
+               | ["http://host/"]             | [None]           |
+               | ["http://host/blog"]         | [Some Overview]  |
+               | ["http://host/post/42"]      | [None]           |
+               | ["http://host/blog/post/42"] | [Some (Post 42)] |}
+        *)
+
+
+
+        (** {1 Query} *)
+
+        module Query:
+        sig
+            (** Parse query parameters *)
+
+
+
+            (** {1 Parsers } *)
+
+            type 'a t
+            (** The query parser type *)
+
+
+            val string: string -> (string option) t
+            (** [string key] will parse the query parameter named [key] as string.
+
+                Both the key and value of the query parameter will be
+                percent-decoded automatically.
+
+                For example. the parser [top </> Query.string "name"] will
+                behave like this:
+
+                {t | input                                   | parse result          |
+                   |-----------------------------------------|-----------------------|
+                   | ["http://host?name=Alice"]              | [Some (Some "Alice")] |
+                   | ["http://host?name=Bob"]                | [Some (Some "Bob")]   |
+                   | ["http://host?name=%D0%91%D0%BE%D0%B1"] | [Some (Some "Боб")]   |
+                   | ["http://host?name="]                   | [Some (Some "")]      |
+                   | ["http://host?name"]                    | [Some None]           |
+                   | ["http://host"]                         | [Some None]           |}
+            *)
+
+
+            val int: string -> (int option) t
+            (** [int key] will parse the query parameter named [key] as integer.
+
+                The key of the query parameter will be percent-decoded
+                automatically.
+
+                For example. the parser [top </> Query.int "year"] will behave
+                like this:
+
+                {t | input                     | parse result       |
+                   |---------------------------|--------------------|
+                   | ["http://host?year=2025"] | [Some (Some 2025)] |
+                   | ["http://host?year=Y2K"]  | [Some None]        |
+                   | ["http://host?year="]     | [Some None]        |
+                   | ["http://host?year"]      | [Some None]        |
+                   | ["http://host"]           | [Some None]        |}
+            *)
+
+
+            val enum: string -> (string * 'a) list -> 'a option t
+            (** [enum key table] will parse the query parameter named [key] as
+                string and will try to transform this string into a value by
+                looking it up in the given [table].
+
+                Example:
+
+                {[
+                    let lang_parser: ([`Haskell | `OCaml | `Rust] option -> 'a, 'a) Parser.t =
+                        let open Parser in
+                        top <?>
+                            Query.enum
+                                "lang"
+                                [("hs", `Haskell); ("ml", `OCaml); ("rs", `Rust)]
+                ]}
+
+                The example parser produces the following results:
+
+                {t | input                   | parse result         |
+                   |-------------------------|----------------------|
+                   | ["http://host?lang=ml"] | [Some (Some `Ocaml)] |
+                   | ["http://host?lang=py"] | [Some None]          |
+                   | ["http://host?lang="]   | [Some None]          |
+                   | ["http://host?lang"]    | [Some None]          |
+                   | ["http://host"]         | [Some None]          |}
+            *)
+
+
+            val custom: string -> (string list -> 'a) -> 'a t
+            (** [custom key f] will parse the query parameter named [key] by
+                applying the function [f] to the list of raw (undecoded) string
+                values referenced by [key] in the query string.
+
+                While the other query parsers, {!string}, {!int} and {!enum},
+                only allow at most one occurrence of a key in the query string,
+                [custom] allows handling multiple occurrences.
+
+                Example:
+
+                {[
+                    let posts: int list option Parser.t =
+                        let open Parser in
+                        top <?> custom "post" (List.filter_map int_of_string)
+                ]}
+
+                The example parser produces the following results:
+
+                {t | input                         | parse result  |
+                   |-------------------------------|---------------|
+                   | ["http://host?post=2"]        | [Some [2]]    |
+                   | ["http://host?post=2&post=7"] | [Some [2; 7]] |
+                   | ["http://host?post=2&post=x"] | [Some [2]]    |
+                   | ["http://host?hats=2"]        | [Some []]     |}
+            *)
+
+
+            (** {1 Mapping} *)
+
+            val map: ('a -> 'b) -> 'a t -> 'b t
+            (** [map f query_parser] transforms the [query_parser] which parses
+                one query parameter via [f].
+
+                Example:
+
+                {[
+                    let search_term_parser: ([`Search of string] -> 'a, 'a) Parser.t =
+                        let open Parser in
+                        top <?>
+                            Query.map
+                                (fun s -> `Search (Option.value ~default:"" s))
+                                (Query.string "search")
+                ]}
+
+                The example parser produces the following results:
+
+                {t | input                        | parse result             |
+                   |------------------------------|--------------------------|
+                   | ["http://host?search=ocaml"] | [Some (`Search "ocaml")] |
+                   | ["http://host?search="]      | [Some (`Search "")]      |
+                   | ["http://host?search"]       | [Some (`Search "")]      |
+                   | ["http://host"]              | [Some (`Search "")]      |}
+            *)
+
+            val map2: ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+            (** [map f query_parser] transforms the [query_parser] which parses
+                two query parameters via [f].
+
+                Example:
+
+                {[
+                    type user = {fname: string option; lname: string option}
+
+                    let user_parser: (user -> 'a, 'a) Parser.t =
+                        let open Parser in
+                        top <?>
+                            Query.map2
+                                (fun fname lname -> {fname; lname})
+                                (Query.string "fname")
+                                (Query.string "lname")
+                ]}
+
+                The example parser produces the following results:
+
+                {t | input                                    | parse result                                           |
+                   |------------------------------------------|--------------------------------------------------------|
+                   | ["http://host?fname=Xavier&lname=Leroy"] | [Some ({fname = Some "Xavier"; lname = Some "Leroy"))] |
+                   | ["http://host?fname=Xavier"]             | [Some ({fname = Some "Xavier"; lname = None})]         |
+                   | ["http://host?"]                         | [Some ({fname = None; lname = None})]                                            |
+                   | ["http://host"]                          | [Some ({fname = None; lname = None})]                                            |}
+            *)
+
+            val map3: ('a -> 'b -> 'c -> 'd) -> 'a t -> 'b t -> 'c t -> 'd t
+            (** [map f query_parser] transforms the [query_parser] which parses
+                three query parameters via [f].
+            *)
+
+
+            val map4:
+                ('a -> 'b -> 'c -> 'd -> 'e) ->
+                'a t ->
+                'b t ->
+                'c t ->
+                'd t ->
+                'e t
+            (** [map f query_parser] transforms the [query_parser] which parses
+                four query parameters via [f].
+            *)
+
+
+            val map5:
+                ('a -> 'b -> 'c -> 'd -> 'e -> 'f) ->
+                'a t ->
+                'b t ->
+                'c t ->
+                'd t ->
+                'e t ->
+                'f t
+            (** [map f query_parser] transforms the [query_parser] which parses
+                five query parameters via [f].
+            *)
+
+
+            val map6:
+                ('a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g) ->
+                'a t ->
+                'b t ->
+                'c t ->
+                'd t ->
+                'e t ->
+                'f t ->
+                'g t
+            (** [map f query_parser] transforms the [query_parser] which parses
+                six query parameters via [f].
+            *)
+
+
+            val map7:
+                ('a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h) ->
+                'a t ->
+                'b t ->
+                'c t ->
+                'd t ->
+                'e t ->
+                'f t ->
+                'g t ->
+                'h t
+            (** [map f query_parser] transforms the [query_parser] which parses
+                seven query parameters via [f].
+            *)
+
+
+            val map8:
+                ('a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h -> 'i) ->
+                'a t ->
+                'b t ->
+                'c t ->
+                'd t ->
+                'e t ->
+                'f t ->
+                'g t ->
+                'h t ->
+                'i t
+            (** [map f query_parser] transforms the [query_parser] which parses
+                eight query parameters via [f].
+            *)
+
+        end
+
+
+        val (<?>): ('a, ('b -> 'c)) t -> 'b Query.t -> ('a, 'c) t
+        (** [url_parser </?> query_parser] combines a [url_parser] with a
+            [query_parser].
+
+            For example, the parser [s "blog" <?> Query.string "search"]
+            produces the following results:
+
+            {t | input                        | parse result          |
+               |------------------------------|-----------------------|
+               | ["http://host/blog"]         | [Some None]           |
+               | ["http://host?search=ocaml"] | [Some (Some "ocaml")] |
+               | ["http://host?search="]      | [Some (Some "")]      |
+               | ["http://host?search"]       | [Some (None)]         |}
+        *)
+
+
+        val query: 'a Query.t -> (('a -> 'b), 'b) t
+        (** [query query_parser] converts [query_parser] to a URL parser.
+
+            This is useful if a URL has an empty path and we want to parse
+            query parameters.
+
+            Example:
+
+            {[
+                (* The following parsers are equivalent *)
+
+                let search_term_parser1: (string -> 'a, 'a) Parser.t =
+                    let open Parser in
+                    query (Query.string "search")
+
+                let search_term_parser2: (string -> 'a, 'a) Parser.t =
+                    let open Parser in
+                    top <?> Query.string "search"
+            ]}
+
+            The example parsers behave as follows:
+
+            {t | input                        | parse result          |
+               |------------------------------|-----------------------|
+               | ["http://host"]              | [Some None]           |
+               | ["http://host?search=ocaml"] | [Some (Some "ocaml")] |
+               | ["http://host?search="]      | [Some (Some "")]      |
+               | ["http://host?search"]       | [Some (None)]         |}
+        *)
+
+
+
+        (** {1 Fragment} *)
+
+        val fragment: (string option -> 'a) -> (('a -> 'b), 'b) t
+        (** [fragment f] creates a fragment parser that produces a value by
+            calling [f] on the fragment part of the URL.
+
+            The fragment part is percent-decoded automatically.
+
+            For example. the parser [s "excercises" </> fragment Fun.id]
+            produces the folloing results:
+
+            {t | input                        | parse result      |
+               |------------------------------|-------------------|
+               | ["http://host/excercises"]   | [Some None]       |
+               | ["http://host/excercises#"]  | [Some (Some "")]  |
+               | ["http://host/excercises#6"] | [Some (Some "6")] |}
+        *)
+
+
+
+        (** {1 Run parsers} *)
+
+        val parse: (('a -> 'a), 'a) t -> url -> 'a option
+        (** [parse parser url] runs the given [parser] on the given [url].
+
+            Example:
+
+            {[
+                type route = Home | Blog of int | Not_found
+
+                let route_parser: (route -> 'a, 'a) Parser.t =
+                    let open Parser in
+                    one_of
+                        [
+                            map Home top;
+                            map (fun id -> Blog id) (s "blog" </> int);
+                        ]
+
+                let route_of_string (str: string): route =
+                    match of_string str with
+                    | None ->
+                        Not_found
+                    | Some url ->
+                        Option.value ~default:Not_found (parse route_parser url)
+            ]}
+
+            The [route_of_string] function above produces the following results:
+
+            {t | input                                        | parse result |
+               |----------------------------------------------|--------------|
+               | ["/blog/42"]                                 | [Not_found]  |
+               | ["https://example.com/"]                     | [Home]       |
+               | ["https://example.com/blog"]                 | [Not_found]  |
+               | ["https://example.com/blog/42"]              | [Blog 42]    |
+               | ["https://example.com/blog/42/"]             | [Blog 42]    |
+               | ["https://example.com/blog/42#introduction"] | [Blog 42]    |
+               | ["https://example.com/blog/42?search=ocaml"] | [Blog 42]    |
+               | ["https://example.com/settings"]             | [Not_found]  |}
+        *)
+
+    end
+
+end

--- a/src/js/fmlib_js.mli
+++ b/src/js/fmlib_js.mli
@@ -13,6 +13,9 @@ module Timer = Timer
 
 module Date  = Date
 
+module Url = Url
+
+
 
 (** {1 Common Browser Modules}
 

--- a/src/js/url.ml
+++ b/src/js/url.ml
@@ -1,0 +1,32 @@
+open Js_of_ocaml
+
+
+let percent_encode (s: string): string =
+    let open Js in
+    (* We can safely ignore the exception encodeURI throws for invalid
+       input because Js.string always produces valid UTF-16. *)
+    s |> string |> encodeURI |> to_string
+
+
+let percent_decode (s: string): string option =
+    let open Js in
+    try s |> string |> decodeURI |> to_string |> Option.some with
+    | _ -> None
+
+
+let percent_encode_component (s: string): string =
+    let open Js in
+    (* We can safely ignore the exception encodeURIComponent throws for invalid
+       input because Js.string always produces valid UTF-16. *)
+    s |> string |> encodeURIComponent |> to_string
+
+
+let percent_decode_component (s: string): string option =
+    let open Js in
+    try s |> string |> decodeURIComponent |> to_string |> Option.some with
+    | _ -> None
+
+
+let current (): string =
+    let open Js in
+    to_string Dom_html.window##.location##.href

--- a/src/js/url.mli
+++ b/src/js/url.mli
@@ -1,0 +1,46 @@
+(** URL utility functions *)
+
+
+val percent_encode: string -> string
+(** [percent_encode s] encodes the given string according to the
+    rules defined in {{:https://datatracker.ietf.org/doc/html/rfc3986} RFC 3986}.
+    This is meant to be called on a full URL. Characters that are part of the
+    URL syntax such as '/' or '?' are preserved.
+
+    This is a wrapper around Javascript's {{:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI} encodeURI}.
+*)
+
+
+val percent_decode: string -> string option
+(** [percent_decode s] decodes the given string according to the
+    rules defined in {{:https://datatracker.ietf.org/doc/html/rfc3986} RFC 3986}.
+    This is meant to be called on a full URL.
+
+    This is a wrapper around Javascript's {{:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURI} decodeURI}.
+*)
+
+
+val percent_encode_component: string -> string
+(** [percent_encode_component s] encodes the given string according to the
+    rules defined in {{:https://datatracker.ietf.org/doc/html/rfc3986} RFC 3986}.
+    This is meant to be called on a URL component (a path, query string, fragment
+    etc.). Characters that are part of the URL syntax such as '/' or '?' are
+    replaced.
+
+    This is a wrapper around Javascript's {{:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent} encodeURIComponent}.
+*)
+
+
+val percent_decode_component: string -> string option
+(** [percent_decode_component s] decodes the given string according to the
+    rules defined in {{:https://datatracker.ietf.org/doc/html/rfc3986} RFC 3986}.
+    This is meant to be called on a URL component (a path, query string, fragment
+    etc.).
+
+    This is a wrapper around Javascript's {{:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent} decodeURIComponent}.
+*)
+
+val current: unit -> string
+(** [current ()] returns the location of the current document
+    ([Window.location]). This is always a full URL, including the scheme and
+    authority parts. *)


### PR DESCRIPTION
Hi Helmut,

here comes my proposal for a new URL API.

It's largely based on the API of [elm/url](https://package.elm-lang.org/packages/elm/url/1.0.0/) with the following changes:

- I implemented some suggestions from [this issue](https://github.com/elm/url/issues/42).
	- ``Url.Builder.string`` (and ``Url.Builder.Query.string``) automatically percent-encode path segments (and query parameters)
	- ``Url.Builder.raw`` (and ``Url.Builder.Query.raw``) don't percent-encode
	- I added ``Url.Builder.Fragment.string`` and ``Url.Builder.Fragment.raw`` for consistency
- I omitted a ``Url.to_string`` function. URLs should really be constructed using the ``Url.Builder`` module.

Some more remarks:

- I added a bunch of unit tests in ``url.ml``. They only work in ``js`` mode. Specifying ``(modes js)`` in ``src/browser/dune`` requires setting ``(lang dune 1.11)`` or higher.
- I hope I understood the usage of the current URL module in ``Handler.Url_request`` correctly. I implemented a local function ``is_page`` that checks if the URL is local, i.e. the origin part matches the current browser location.
- I'm unsure if the name of the module ``Url.Parser`` is the right choice or if we should call it ``Url.Decoder``, analogous to the existing ``Decoder`` module.
- ``Url.Parser.Query.enum`` could also take a ``'a Dictionary.t`` instead of an association list. That would require exposing the ``Dictionary`` module as a public API.
- I could have used some functions from the ``Js_of_ocaml.Url`` module, but I decided against it for several reasons, e.g.
	- ``url_of_string`` behaves weirdly, it returns an option type but also throws exceptions
	- percent-encoding and percent-decoding is done by calling the deprecated Javascript functions [escape](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/escape) and [unescape](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/unescape)
- Only ``http`` and ``https`` URLs are supported. This is something that people complained about on the ``elm/url`` issue tracker, but supporting more protocols would require quite some re-design I think.

Closes #20.

Cheers,
Christian