### PR TITLE
expose value decoder, add optional_field decoder

### DIFF
--- a/src/browser/decoder_intf.ml
+++ b/src/browser/decoder_intf.ml
@@ -187,6 +187,14 @@ sig
     *)
 
 
+    val optional_field: string -> 'a t -> 'a option t
+    (** [optional_field name dec] If a field named [name] exists in the
+        javascript object, decode it with the decoder [dec] and return
+        the decoded value wrapped in [Some]. If the field does not exist,
+        return [None].
+    *)
+
+
     val array: 'a t -> 'a array t
     (** [array dec] Decode a javascript array into an ocaml array using [dec] to
         decode elements.

--- a/src/browser/decoder_intf.ml
+++ b/src/browser/decoder_intf.ml
@@ -138,6 +138,23 @@ sig
     *)
 
 
+    val value: value t
+    (** Return the javascript value without decoding it.
+
+        For example: We want to know if a field in a javascript object
+        exists, but don't want to decode it.
+
+        {[
+            let* avatar = optional_field "avatar" value in
+            match avatar with
+            | Some _ ->
+                print_endline "avatar exists"
+            | None ->
+                print_endline "avatar does not exist"
+        ]}
+    *)
+
+
     val int: int t
     (** Decode an integer value i.e. a number between [-2^31] and [2^31 - 1].
     *)

--- a/src/js/base.ml
+++ b/src/js/base.ml
@@ -208,6 +208,19 @@ struct
             )
 
 
+    let optional_field (name: string) (decode: 'a t): 'a option t =
+        let* v = map Option.return (field name value) </> return None in
+        match v with
+        | None ->
+            return None
+        | Some v -> (
+            match decode v with
+            | None ->
+                fail
+            | decoded ->
+                return decoded)
+
+
     let array (decode: 'a t): 'a array t =
         fun obj ->
         let open Js in

--- a/src/js/base.mli
+++ b/src/js/base.mli
@@ -289,6 +289,14 @@ sig
     *)
 
 
+    val optional_field: string -> 'a t -> 'a option t
+    (** [optional_field name dec] If a field named [name] exists in the
+        javascript object, decode it with the decoder [dec] and return
+        the decoded value wrapped in [Some]. If the field does not exist,
+        return [None].
+    *)
+
+
     val array:      'a t -> 'a array t
     (** [array dec] Decode a javascript array into an ocaml array using [dec] to
         decode elements.


### PR DESCRIPTION
Hi Helmut,

I had the following problem:

I wanted to decode Javascript objects into a ``person`` data type like this:

``` ocaml
type person =
  { name : string
  ; age : int option
  }
```

I'm handling Javascript objects where the ``age`` field is optional in the sense that it's sometimes absent. At the same time *if* the ``age`` field is present, I want to detect wrong data types. So this is how I would like to decode objects:

| javascript input                    | decoding result                            |
| ----------------------------------- | ------------------------------------------ |
| ``{name: "Bob", age: 42}``          | ``Some {name = "Bob"; age = Some 42}``     |
| ``{name: "Bob"}``                   | ``Some {name = "Bob"; age = None}``        |
| ``{name: "Bob", age: "forty-two"}`` | ``None``                                   |

I believe that implementing this behaviour is currently not possible with ``Fmlib_browser.Decoder``, please correct me if I'm wrong.

My first intuition was to use the ``option`` decoder (because it's an optional field) but then I realized that it only allows handling ``null`` values, but *absent* fields are not ``null``.

Then I tried to build a decoder using ``</>``:

``` ocaml
let person_decoder =
  let* name = field "name" string in
  let* age = map Option.some (field "age" int) </> return None in
  return {name; age}
```

This decoder works for the first two inputs, but still returns ``Some {name = "Bob"; age = None}`` on the third input, so it silently ignores the wrong data type of the ``age`` field.

By exposing the ``value`` decoder (this PR), I managed to implement the desired behaviour:

``` ocaml
let person_decoder =
  let* name = field "name" string in
  let* age_value = map Option.some (field "age" value) </> return None in
  match age_value with
  | None ->
      return {name; age = None}
  | Some v -> begin
      match run int v with
      | None ->
          fail
      | age ->
          return {name; age}
    end
```

[elm/json](https://package.elm-lang.org/packages/elm/json/latest/Json-Decode#value) has a ``value`` decoder too, by the way.

Let me know what you think.

Christian

