### PR TITLE
fail http_request task on network errors

### DIFF
--- a/src/browser/task.ml
+++ b/src/browser/task.ml
@@ -322,7 +322,7 @@ let http_request
     let handler _ =
         assert (Http_request.ready_state req = 4);
         let status = Http_request.status req in
-        if status >= 300 then (* not ok *)
+        if status = 0 || status >= 300 then (* not ok *)
             continue k (Error (`Status status))
         else
             continue k (expect req)


### PR DESCRIPTION
Hi Helmut,

I realized that when I send a HTTP request and a network error occurs (e.g. ``NS_ERROR_CONNECTION_REFUSED``), the ``http_request`` task still succeeds. It only fails if the HTTP status code is greater than or equal to 300. In the case of network errors, the status code [is set to 0](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/status) though.

 This can cause bugs, where the user thinks a request has been sent successfully, but the request actually never reached the server.

I chose the simplest path to fix this: Check if the status code is 0 in the ``loadend`` event handler and report the `` `Status 0`` error message to the user. An alternative would be to introduce a new error message, e.g. `` `Network``, but it's not clear to me, if there are other error conditions that can lead to status code 0.

Cheers
Christian